### PR TITLE
Fixed small issues with puppet

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Install a database server with Microsoft SQL Server 2008 R2
 Download and install the latest version of Puppet with the following Powershell commands. Be sure to replace PUPPET_MASTER_SERVER=puppetmaster with your puppetmasters hostname. This can easily be found by going to the puppetmaster and doing "ls /var/lib/puppet/ssl/certs/".
 
 	Dism /online /Enable-Feature /FeatureName:NetFx3 /All
-	(new-object System.Net.WebClient).Downloadfile("https://downloads.puppetlabs.com/windows/puppet-3.6.2.msi", "puppet.msi") 
+	(new-object System.Net.WebClient).Downloadfile("https://downloads.puppetlabs.com/windows/puppet-latest.msi", "puppet.msi") 
 	msiexec /qn /i puppet.msi PUPPET_MASTER_SERVER=puppetmaster
 
 Run puppet agent, you will find it on the start menu under puppet -> run puppet agent.
@@ -39,7 +39,7 @@ Approve the certificate on the puppet master
 
 Run the following script to connect the node to Puppet Master, replace <puppetmaster> with the hostname of your Puppet Master.
 
-	wget --no-check-certificate https://raw.github.com/atomia/installation/master/Files/bootstrap_linux.sh && chmod +x bootstrap_linux.sh
+	wget --no-check-certificate https://raw.github.com/atomia/puppet-atomia/master/files/bootstrap_linux.sh && chmod +x bootstrap_linux.sh
 	./bootstrap_linux.sh <puppetmaster>
 	rm boostrap_linux.sh
 

--- a/files/bootstrap_linux.sh
+++ b/files/bootstrap_linux.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+if [ "$#" -ne 1 ]; then
+        echo "Usage: $0 puppetmaster"
+        exit 1
+fi
+hostname=`hostname`
+dist=`cat /etc/*-release | egrep ^ID= | sed 's/.*=//'`
+
+if [ "$dist" = "ubuntu" ]; then
+        wget http://apt.puppetlabs.com/puppetlabs-release-precise.deb
+        sudo dpkg -i puppetlabs-release-precise.deb
+else
+        wget http://apt.puppetlabs.com/puppetlabs-release-wheezy.deb
+        dpkg -i puppetlabs-release-wheezy.deb
+fi
+sudo apt-get update
+apt-get install -y puppet
+
+sed -i 's/START=no/START=yes/' /etc/default/puppet
+sed -i "/\[main\]/a server=$1\nlisten=true" /etc/puppet/puppet.conf
+sed -i "/templatedir/d" /etc/puppet/puppet.conf
+echo -e 'path /run\nallow *' >> /etc/puppet/auth.conf
+
+puppet agent --test
+
+echo "Please sign the certificate on the puppetmaster\npuppet cert sign $hostname \npress any key when done..."
+
+service puppet start
+
+if [ "$dist" = "debian" ]; then
+        puppet agent --enable
+fi
+#Clean up
+rm puppetlabs-release-*.deb
+
+
+exit 1

--- a/files/install_atomia_puppetmaster.sh
+++ b/files/install_atomia_puppetmaster.sh
@@ -8,6 +8,8 @@ dpkg -i puppetlabs-release-$DISTNAME.deb
 rm puppetlabs-release-$DISTNAME.deb
 apt-get update
 apt-get install -y puppetmaster git apache2-utils curl rubygems
+# Following should remove annoying templatedir deprecation warning
+sed -i "/templatedir/d" /etc/puppet/puppet.conf
 cd /etc/puppet
 puppet resource package puppetdb ensure=latest
 puppet resource service puppetdb ensure=running enable=true
@@ -67,6 +69,7 @@ master:
       cache: yaml
 " >  /etc/puppet/routes.yaml
 
+curl -sSL https://rvm.io/mpapis.asc | gpg --import -
 curl -sSL https://get.rvm.io | bash -s stable
 
 


### PR DESCRIPTION
- Moved bootstrap_linux.sh from obsolete installation repository, and updated README.md file to point to the right one
- Changed path for windows puppet agent to point to the latest one in README.md
- Added lines to remove annoying templatedir deprecation warning on both master and agents