### PR TITLE
Fixes chocolatey paths

### DIFF
--- a/manifests/windows_base.pp
+++ b/manifests/windows_base.pp
@@ -183,12 +183,12 @@ class atomia::windows_base (
   exec { 'install-chocolatey':
     command => "iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))",
     provider  => powershell,
-    onlyif  => 'Test-Path C:\Chocolatey'
+    onlyif  => 'Test-Path C:\ProgramData\Chocolatey'
   }
   
   exec { 'set-chocolatey-path':
-    command => 'c:\windows\system32\cmd.exe /c SET PATH=%PATH%;%systemdrive%\chocolatey\bin',
-    creates => "c:/install/chocolatey_installed.txt",
+    command => 'c:\windows\system32\cmd.exe /c SET PATH=%PATH%;%systemdrive%\ProgramData\chocolatey\bin',
+    creates => 'c:/install/chocolatey_installed.txt',
     require  => Exec['install-chocolatey'],
   }
   


### PR DESCRIPTION
https://github.com/chocolatey/chocolatey/wiki/ChocolateyFAQs says:
```
Where does chocolatey install by default?

As of version 0.9.8.24, binaries, libraries and Chocolatey components install in C:\ProgramData\chocolatey (environment variable %ProgramData%) by default. This reduces the attack surface on a local installation of Chocolatey and limits who can make changes to the directory.
```