### PR TITLE
strip CloudLinux minor versions from major_version

### DIFF
--- a/files/bootstrap_linux.sh
+++ b/files/bootstrap_linux.sh
@@ -21,7 +21,7 @@ if [ -e '/etc/debian_version' ]; then
 elif [ -e '/etc/redhat-release' ]; then
 	for os_release in redhat-release centos-release cloudlinux-release; do
 		if rpm -q --quiet $os_release; then
-			major_version=$(rpm -q --queryformat '%{VERSION}' $os_release)
+			major_version=$(rpm -q --queryformat '%{VERSION}' $os_release|cut -d. -f1)
 		fi
 	done
         if ! rpm -q --quiet puppet puppetlabs-release; then


### PR DESCRIPTION
This addition makes sure we only have a major version to work with. Turns
out VERSION queryformat doesn't consistently return only the major version but, in
a sidecase, also returns the minor version on cloudlinux 7. ex;

CloudLinux 7
rpm -q --queryformat '%{VERSION}' cloudlinux-release|cut -d. -f1
7.2

CloudLinux 6
rpm -q --queryformat '%{VERSION}' cloudlinux-release|cut -d. -f1
6

CentOS 7
rpm -q --queryformat '%{VERSION}' centos-release|cut -d. -f1
7

CentOS 6
rpm -q --queryformat '%{VERSION}' centos-release|cut -d. -f1
6