### PR TITLE
add support for Redhat family mailservers

### DIFF
--- a/manifests/bootstrap.pp
+++ b/manifests/bootstrap.pp
@@ -1,7 +1,11 @@
 class atomia::bootstrap
 {
   if $kernel == "Linux" {
-     file { "/usr/lib/ruby/vendor_ruby/facter/atomia_role.rb":
+    case $osfamily {
+      'RedHat' : { $facter_path = '/usr/share/ruby/vendor_ruby/facter' }
+      default  : { $facter_path = '/usr/lib/ruby/vendor_ruby/facter' }
+    }
+     file { "${facter_path}/atomia_role.rb":
        owner  => root,
        group  => root,
        mode   => "755",


### PR DESCRIPTION
With these changes both ubuntu and redhat based servers can be installed. I left out glusterfs support because we don't need it at oxilion and I was unable to test it.