### PR TITLE
attempt to clean up all manifests

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,6 +2,9 @@ require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet-lint/tasks/puppet-lint'
 require 'puppet-syntax/tasks/puppet-syntax'
 
+#FIXME: disabling autoloader via disable_checks didn't work
+PuppetLint.configuration.send("disable_autoloader_layout")
+
 exclude_paths = [
   "pkg/**/*",
   "vendor/**/*",

--- a/manifests/active_directory.pp
+++ b/manifests/active_directory.pp
@@ -3,7 +3,7 @@
 ### Deploys and configures Active Directory
 
 ### Variable documentation
-#### domain_name: The Active Directory domain name for your environment. 
+#### domain_name: The Active Directory domain name for your environment.
 #### netbios_domain_name: Short version of the domain name. Example ATOMIA
 #### restore_password: Password used for Active Directory restore
 #### app_password: Password for the Atomia apppooluser
@@ -21,76 +21,76 @@
 ##### is_master(advanced): %hide
 
 class atomia::active_directory (
-  $domain_name = "",
-  $netbios_domain_name = "",
-  $restore_password = "",
-  $app_password = "",
-  $bind_password = "",
-  $windows_admin_password = "",
-  $is_master = 1,
+  $domain_name            = '',
+  $netbios_domain_name    = '',
+  $restore_password       = '',
+  $app_password           = '',
+  $bind_password          = '',
+  $windows_admin_password = '',
+  $is_master              = 1,
 
 ) {
 
   File { source_permissions => ignore }
 
   # Set ip correctly when on ec2
-  if $ec2_public_ipv4 {
-    $public_ip = $ec2_public_ipv4
+  if $::ec2_public_ipv4 {
+    $public_ip = $::ec2_public_ipv4
   } else {
-    $public_ip = $ipaddress_eth0
+    $public_ip = $::ipaddress_eth0
   }
 
-  atomia::adjoin::register{ "${::fqdn}": content => $ipaddress, name=> $fqdn}
+  atomia::adjoin::register{ $::fqdn: content => $::ipaddress, name=> $::fqdn}
 
-  if !defined(File["c:/install"]) {
+  if !defined(File['c:/install']) {
     file { 'c:/install':
       ensure => 'directory',
     }
   }
 
   file { 'c:/install/sync_time.ps1':
-    ensure => 'file',
+    ensure  => 'file',
     content => template('atomia/active_directory/sync_time.ps1.erb'),
     require => File['c:/install'],
   }
 
   if($is_master == 1 and !$::vagrant) {
-    atomia::active_directory::store_ip{ "${::fqdn}": content => $ipaddress}
+    atomia::active_directory::store_ip{ $::fqdn: content => $::ipaddress}
 
-      #@@host { "domain-name-host":
-      #    name		=> "$domain_name",
-      #    ip	=> "${ipaddress}"
-      #}
-  
-  	@@bind::zone {"domain-forward":
-      zone_contact => "contact.${domain_name}",
-      zone_ns      => ["ns0.${domain_name}"],
-      zone_serial  => '2012112901',
-      zone_ttl     => '604800',
-      zone_origin  => "${domain_name}",
-      zone_type    => "forward",
-      zone_forwarders => $ip_address,
-	   }
+    #@@host { "domain-name-host":
+    #    name		=> "$domain_name",
+    #    ip	=> "${ipaddress}"
+    #}
+
+    @@bind::zone {'domain-forward':
+      zone_contact    => "contact.${domain_name}",
+      zone_ns         => ["ns0.${domain_name}"],
+      zone_serial     => '2012112901',
+      zone_ttl        => '604800',
+      zone_origin     => $domain_name,
+      zone_type       => 'forward',
+      zone_forwarders => $::ip_address,
+    }
 
     file { 'C:\ProgramData\PuppetLabs\facter\facts.d\atomia_role_ad.ps1':
       content => template('atomia/active_directory/atomia_role_active_directory.ps1.erb'),
     }
 
-    exec { "enable-ad-feature":
-      command   => "Install-windowsfeature -name AD-Domain-Services -IncludeManagementTools",
-      unless    => "Import-Module ServerManager; if (@(Get-WindowsFeature AD-Domain-Services | ?{$_.Installed -match 'false'}).count -eq 0) { exit 1 }",
-      provider  => powershell,
+    exec { 'enable-ad-feature':
+      command  => 'Install-windowsfeature -name AD-Domain-Services -IncludeManagementTools',
+      unless   => "Import-Module ServerManager; if (@(Get-WindowsFeature AD-Domain-Services | ?{\${_}.Installed -match 'false'}).count -eq 0) { exit 1 }",
+      provider => powershell,
     }
 
     exec { 'Install AD forest':
-      command => "Import-Module ADDSDeployment; Install-ADDSForest -DomainName ${domain_name} -DomainMode Win2008 -DomainNetBIOSName ${netbios_domain_name} -ForestMode Win2008 -SafeModeAdministratorPassword (convertto-securestring '${restore_password}' -asplaintext -force) -InstallDns -Force",
-      provider    => powershell,
-      onlyif      => "if((gwmi WIN32_ComputerSystem).Domain -eq '${domain_name}'){exit 1}",
-      require   => Exec["enable-ad-feature"]
+      command  => "Import-Module ADDSDeployment; Install-ADDSForest -DomainName ${domain_name} -DomainMode Win2008 -DomainNetBIOSName ${netbios_domain_name} -ForestMode Win2008 -SafeModeAdministratorPassword (convertto-securestring '${restore_password}' -asplaintext -force) -InstallDns -Force",
+      provider => powershell,
+      onlyif   => "if((gwmi WIN32_ComputerSystem).Domain -eq '${domain_name}'){exit 1}",
+      require  => Exec['enable-ad-feature']
     }
 
     file { 'c:/install/add_users.ps1':
-      ensure => 'file',
+      ensure  => 'file',
       content => template('atomia/active_directory/add_users.ps1.erb'),
       require => Exec['Install AD forest']
     }
@@ -100,84 +100,84 @@ class atomia::active_directory (
       require => [File['c:/install/add_users.ps1'], Exec['Install AD forest']],
     }
 
-	$internal_zone = hiera('atomia::internaldns::zone_name')
-	$internal_ip = hiera('atomia::internaldns::ip_address')
+    $internal_zone = hiera('atomia::internaldns::zone_name')
+    $internal_ip = hiera('atomia::internaldns::ip_address')
 
-	exec { 'add-conditional-forwarder-internaldns':
-		command		=> "Add-DnsServerConditionalForwarderZone -Name ${internal_zone} -MasterServers ${internal_ip}",
-		provider	=> powershell,
-		require		=> Exec['Install AD forest'],
-		onlyif		=> "if((Get-DnsServerZone -Name ${internal_zone}).ZoneName -Match '${internal_zone}') {exit 1}",
-	}
+    exec { 'add-conditional-forwarder-internaldns':
+      command  => "Add-DnsServerConditionalForwarderZone -Name ${internal_zone} -MasterServers ${internal_ip}",
+      provider => powershell,
+      require  => Exec['Install AD forest'],
+      onlyif   => "if((Get-DnsServerZone -Name ${internal_zone}).ZoneName -Match '${internal_zone}') {exit 1}",
+    }
 
   } elsif($::vagrant) {
-      file { 'c:/install/add_users_vagrant.ps1':
-  	    ensure => 'file',
-  	    content => template('atomia/active_directory/add_users_vagrant.ps1.erb'),
-      }
-      exec { 'add-ad-users-vagrant':
-        command => 'C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -executionpolicy remotesigned -file c:/install/add_users_vagrant.ps1',
-        creates => 'C:\install\installed',
-        require => File['c:/install/add_users_vagrant.ps1'],
-      }
+    file { 'c:/install/add_users_vagrant.ps1':
+      ensure  => 'file',
+      content => template('atomia/active_directory/add_users_vagrant.ps1.erb'),
+    }
+    exec { 'add-ad-users-vagrant':
+      command => 'C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -executionpolicy remotesigned -file c:/install/add_users_vagrant.ps1',
+      creates => 'C:\install\installed',
+      require => File['c:/install/add_users_vagrant.ps1'],
+    }
 
   } else {
     file { 'C:\ProgramData\PuppetLabs\facter\facts.d\atomia_role_ad.ps1':
       content => template('atomia/active_directory/atomia_role_active_directory_replica.ps1.erb'),
     }
-    
+
     $factfile = 'C:/ProgramData/PuppetLabs/facter/facts.d/domain_controller.txt'
-   
+
     concat { $factfile:
       ensure => present,
-    }    
-    
+    }
+
     Concat::Fragment <<| tag == 'dc_ip' |>>
 
     exec { 'set-dns':
-      command => "Set-DNSClientServerAddress -interfaceIndex 12 -ServerAddresses (\"$active_directory_ip\")",
+      command  => "Set-DNSClientServerAddress -interfaceIndex 12 -ServerAddresses (\"${atomia::active_directory::active_directory_ip}\")",
       provider => powershell,
-      unless => 'if(Get-DnsClientServerAddress -InterfaceIndex 12 | Where-Object {$_.ServerAddresses -like "*${active_directory_ip}*"}) { exit 1 }',
+      unless   => "if(Get-DnsClientServerAddress -InterfaceIndex 12 | Where-Object {\$_.ServerAddresses -like \"*${atomia::active_directory::active_directory_ip}*\"}) { exit 1 }",
     }
-    ->
-    exec { "enable-ad-feature":
-      command   => "Install-windowsfeature -name AD-Domain-Services -IncludeManagementTools",
-      unless    => "Import-Module ServerManager; if (@(Get-WindowsFeature AD-Domain-Services | ?{$_.Installed -match 'false'}).count -eq 0) { exit 1 }",
-      provider  => powershell,
-    }
+  ->
+  exec { 'enable-ad-feature':
+    command  => 'Install-windowsfeature -name AD-Domain-Services -IncludeManagementTools',
+    unless   => "Import-Module ServerManager; if (@(Get-WindowsFeature AD-Domain-Services | ?{\${_}.Installed -match 'false'}).count -eq 0) { exit 1 }",
+    provider => powershell,
+  }
 
-    #$secpasswd = ConvertTo-SecureString '${windows_admin_password}' -AsPlainText -Force;$credentials = New-Object System.Management.Automation.PSCredential ('${netbios_domain_name\\WindowsAdmin}', $secpasswd);Import-Module ADDSDeployment;
-    exec { 'Install AD replica':
-      command   => template('atomia/active_directory/ad-replica.ps1.erb'), 
-      unless   => "if((gwmi WIN32_ComputerSystem).Domain -ne \"$domain_name\") { exit 1 }",
-      require   => Exec['enable-ad-feature'],
-      provider  => powershell,
-    }
-  }    
-    
+  #$secpasswd = ConvertTo-SecureString '${windows_admin_password}' -AsPlainText -Force;$credentials = New-Object System.Management.Automation.PSCredential ('${netbios_domain_name\\WindowsAdmin}', $secpasswd);Import-Module ADDSDeployment;
+  exec { 'Install AD replica':
+    command  => template('atomia/active_directory/ad-replica.ps1.erb'),
+    unless   => "if((gwmi WIN32_ComputerSystem).Domain -ne \"${domain_name}\") { exit 1 }",
+    require  => Exec['enable-ad-feature'],
+    provider => powershell,
+  }
+  }
+
   exec { 'sync-time':
     command => 'C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -executionpolicy remotesigned -file c:/install/sync_time.ps1',
     require => File['c:/install/sync_time.ps1'],
   }
 }
 
-define atomia::active_directory::store_ip ($content="", $order='10') {
+define atomia::active_directory::store_ip ($content='', $order='10') {
   $factfile = 'C:/ProgramData/PuppetLabs/facter/facts.d/domain_controller.txt'
 
-  @@concat::fragment {"active_directory_ip_${fqdn}":
-      target => $factfile,
-      content => "active_directory_ip=${content} ",
-      tag => 'dc_ip',
-      order => 3
-    }
-    
+  @@concat::fragment {"active_directory_ip_${::fqdn}":
+    target  => $factfile,
+    content => "active_directory_ip=${content} ",
+    tag     => 'dc_ip',
+    order   => 3
+  }
+
   $factfile_linux= '/etc/facter/facts.d/ad_server.txt'
 
-  @@concat::fragment {"active_directory_ip__linux_${fqdn}":
-      target => $factfile_linux,
-      content => "ad_server=${content}",
-      tag => 'dc_ip_linux',
-      order => 3
-    }    
+  @@concat::fragment {"active_directory_ip__linux_${::fqdn}":
+    target  => $factfile_linux,
+    content => "ad_server=${content}",
+    tag     => 'dc_ip_linux',
+    order   => 3
+  }
 
 }

--- a/manifests/adjoin.pp
+++ b/manifests/adjoin.pp
@@ -23,140 +23,141 @@
 class atomia::adjoin (
   # AD domain name
   $domain_name    = hiera('atomia::active_directory::domain_name', ''),
-  $admin_user     = "WindowsAdmin",
+  $admin_user     = 'WindowsAdmin',
   $admin_password = hiera('atomia::active_directory::windows_admin_password', ''),
-  $bind_user      = "PosixGuest",
+  $bind_user      = 'PosixGuest',
   $bind_password  = hiera('atomia::active_directory::bind_password', ''),
   $no_nscd        = 1,) {
-  if $operatingsystem == 'windows' {
+    if $::operatingsystem == 'windows' {
 
-	$ad_factfile = 'C:/ProgramData/PuppetLabs/facter/facts.d/domain_controller.txt'
-    concat { $ad_factfile:
-      ensure => present,
-    }
+      $ad_factfile = 'C:/ProgramData/PuppetLabs/facter/facts.d/domain_controller.txt'
+      concat { $ad_factfile:
+        ensure => present,
+      }
 
-    Concat::Fragment <<| tag == 'dc_ip' |>>
+      Concat::Fragment <<| tag == 'dc_ip' |>>
 
-    exec { 'set-dns':
-      command => "Set-DNSClientServerAddress -interfaceIndex 12 -ServerAddresses (\"$active_directory_ip\")",
-      provider => powershell,
-      unless => 'if(Get-DnsClientServerAddress -InterfaceIndex 12 | Where-Object {$_.ServerAddresses -like "*${active_directory_ip}*"}) { exit 1 }',
-    }
+      exec { 'set-dns':
+        command  => "Set-DNSClientServerAddress -interfaceIndex 12 -ServerAddresses (\"${atomia::active_directory::active_directory_ip}\")",
+        provider => powershell,
+        unless   => "if(Get-DnsClientServerAddress -InterfaceIndex 12 | Where-Object {\$_.ServerAddresses -like '*${atomia::active_directory::active_directory_ip}*'}) { exit 1 }",
+      }
     ->
     Host <<| |>>
-	->
-    exec { 'join-domain':
-      command  => "netdom join $hostname /Domain:$domain_name  /UserD:$admin_user /PasswordD:\"$admin_password\" /REBoot:5",
-      unless   => "if((gwmi WIN32_ComputerSystem).Domain -ne \"$domain_name\") { exit 1 }",
-      provider => powershell
+  ->
+  exec { 'join-domain':
+    command  => "netdom join ${::hostname} /Domain:${domain_name}  /UserD:${admin_user} /PasswordD:\"${admin_password}\" /REBoot:5",
+    unless   => "if((gwmi WIN32_ComputerSystem).Domain -ne \"${domain_name}\") { exit 1 }",
+    provider => powershell
+  }
+
+} else {
+  # Join AD on Linux
+  $dc=regsubst($domain_name, '\.', ',dc=', 'G')
+  $base_dn = "cn=Users,dc=${dc}"
+  # Set ad_servers fact
+
+  if $::vagrant {
+    $ad_servers = 'ldap://192.168.33.10'
+  } else {
+    $factfile = '/etc/facter/facts.d/ad_servers.txt'
+
+    if !defined(File['/etc/facter']) {
+      file { '/etc/facter':
+        ensure => directory,
+      }
+      file { '/etc/facter/facts.d':
+        ensure  => directory,
+        require => File['/etc/facter']
+      }
     }
 
-  } else {
-    # Join AD on Linux  
-      $dc=regsubst($domain_name, '\.', ',dc=', 'G')
-      $base_dn = "cn=Users,dc=${$dc}"
-      # Set ad_servers fact
+    concat { $factfile:
+      ensure  => present,
+      require => File['/etc/facter/facts.d']
+    }
 
-      if $::vagrant {
-        $ad_servers = "ldap://192.168.33.10"
-      } else {
-        $factfile = '/etc/facter/facts.d/ad_servers.txt'
-
-        if !defined(File['/etc/facter']) {
-            file { '/etc/facter':
-            ensure => directory,
-            }
-            file { '/etc/facter/facts.d':
-            ensure => directory,
-            require => File['/etc/facter']
-            }
-        }
-
-        concat { $factfile:
-          ensure => present,
-          require => File['/etc/facter/facts.d']
-        }
-        concat::fragment {"active_directory_${content}":
-            target => $factfile,
-            content => "ad_servers=",
-            tag => 'ad_servers',
-            order => 3
-          } ->
-        Concat::Fragment <<| tag == 'ad_servers' |>>
-
-      }
-
-      if($osfamily == 'RedHat') { 
-          
-        package { nss-pam-ldapd: ensure => present }
-          
-        file { "/etc/nslcd.conf":
-            ensure  => file,
-            owner   => nslcd,
-            group   => ldap,
-            mode    => "600",
-            content => template("atomia/adjoin/nslcd.conf.erb"),
-            require => Package['nss-pam-ldapd'],
-        }            
-      }
-      else {
-          
-        package { libpam-ldap: ensure => present }
-        
-        file { "/etc/ldap.conf":
-            ensure  => file,
-            owner   => root,
-            group   => root,
-            mode    => "644",
-            content => template("atomia/adjoin/ldap.conf.erb"),
-        }    
-     }
-
-      file { "/etc/pam.d/common-account":
-        ensure => file,
-        owner  => root,
-        group  => root,
-        mode   => "644",
-        source => "puppet:///modules/atomia/adjoin/common-account",
-      }
-
-     file { "/etc/nsswitch.conf":
-       ensure => file,
-       owner  => root,
-       group  => root,
-       mode   => "644",
-       source => "puppet:///modules/atomia/adjoin/nsswitch.conf",
-     }
-
-
-   file { "/etc/pam.d/common-auth":
-     ensure => file,
-     owner  => root,
-     group  => root,
-     mode   => "644",
-     source => "puppet:///modules/atomia/adjoin/common-auth",
-   }
-
-   file { "/etc/pam.d/common-session":
-     ensure => file,
-     owner  => root,
-     group  => root,
-     mode   => "644",
-     source => "puppet:///modules/atomia/adjoin/common-session",
-   }
+    concat::fragment {'active_directory':
+      target  => $factfile,
+      content => 'ad_servers=',
+      tag     => 'ad_servers',
+      order   => 3
+    } ->
+    Concat::Fragment <<| tag == 'ad_servers' |>>
 
   }
+
+  if($::osfamily == 'RedHat') {
+
+    package { 'nss-pam-ldapd': ensure => present }
+
+    file { '/etc/nslcd.conf':
+      ensure  => file,
+      owner   => 'nslcd',
+      group   => 'ldap',
+      mode    => '0600',
+      content => template('atomia/adjoin/nslcd.conf.erb'),
+      require => Package['nss-pam-ldapd'],
+    }
+  }
+  else {
+
+    package { 'libpam-ldap': ensure => present }
+
+    file { '/etc/ldap.conf':
+      ensure  => file,
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0644',
+      content => template('atomia/adjoin/ldap.conf.erb'),
+    }
+  }
+
+  file { '/etc/pam.d/common-account':
+    ensure => file,
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0644',
+    source => 'puppet:///modules/atomia/adjoin/common-account',
+  }
+
+  file { '/etc/nsswitch.conf':
+    ensure => file,
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0644',
+    source => 'puppet:///modules/atomia/adjoin/nsswitch.conf',
+  }
+
+
+  file { '/etc/pam.d/common-auth':
+    ensure => file,
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0644',
+    source => 'puppet:///modules/atomia/adjoin/common-auth',
+  }
+
+  file { '/etc/pam.d/common-session':
+    ensure => file,
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0644',
+    source => 'puppet:///modules/atomia/adjoin/common-session',
+  }
+
 }
+  }
 
 
-define atomia::adjoin::register ($content="", $res_name="", $order='10') {
-  $factfile = '/etc/facter/facts.d/ad_servers.txt'
+  define atomia::adjoin::register ($content='', $res_name='', $order='10') {
+    $factfile = '/etc/facter/facts.d/ad_servers.txt'
 
-  @@concat::fragment {"active_directory_${content}_${res_name}":
-      target => $factfile,
+    @@concat::fragment {"active_directory_${content}_${res_name}":
+      target  => $factfile,
       content => "ldap://${content} ",
-      tag => 'ad_servers',
-      order => 3
+      tag     => 'ad_servers',
+      order   => 3
     }
 
-}
+  }

--- a/manifests/adjoin_config.pp
+++ b/manifests/adjoin_config.pp
@@ -1,83 +1,80 @@
 class atomia::adjoin_config (
 
-  ){
+){
   $factfile = '/etc/facter/facts.d/ad_servers.txt'
 
   file { '/etc/facter':
     ensure => directory,
   }
   file { '/etc/facter/facts.d':
-    ensure => directory,
+    ensure  => directory,
     require => File['/etc/facter']
   }
   concat { $factfile:
-    ensure => present,
+    ensure  => present,
     require => File['/etc/facter/facts.d']
   }
-  concat::fragment {"active_directory_${content}":
-      target => $factfile,
-      content => "ad_servers=",
-      tag => 'ad_servers',
-      order => 3
-    } ->
+  concat::fragment {'active_directory_content':
+    target  => $factfile,
+    content => 'ad_servers=',
+    tag     => 'ad_servers',
+    order   => 3
+  } ->
   Concat::Fragment <<| tag == 'ad_servers' |>>
 
-  service { nscd:
-   enable    => false,
-   ensure    => stopped,
+  service { 'nscd':
+    ensure => stopped,
+    enable => false,
   }
-  file { "/etc/pam.d/common-account":
+  file { '/etc/pam.d/common-account':
     ensure => file,
-    owner  => root,
-    group  => root,
-    mode   => "644",
-    source => "puppet:///modules/atomia/adjoin/common-account",
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0644',
+    source => 'puppet:///modules/atomia/adjoin/common-account',
   }
 
-   file { "/etc/nsswitch.conf":
-     ensure => file,
-     owner  => root,
-     group  => root,
-     mode   => "644",
-     source => "puppet:///modules/atomia/adjoin/nsswitch.conf",
-   }
-
-   file { "/etc/ldap.conf":
-     ensure  => file,
-     owner   => root,
-     group   => root,
-     mode    => "644",
-     content => template("atomia/adjoin/ldap.conf.erb"),
-   }
-
+  file { '/etc/nsswitch.conf':
+    ensure => file,
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0644',
+    source => 'puppet:///modules/atomia/adjoin/nsswitch.conf',
   }
 
-  file { "/etc/pam.d/common-auth":
-   ensure => file,
-   owner  => root,
-   group  => root,
-   mode   => "644",
-   source => "puppet:///modules/atomia/adjoin/common-auth",
+  file { '/etc/ldap.conf':
+    ensure  => file,
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    content => template('atomia/adjoin/ldap.conf.erb'),
   }
 
-  file { "/etc/pam.d/common-session":
-   ensure => file,
-   owner  => root,
-   group  => root,
-   mode   => "644",
-   source => "puppet:///modules/atomia/adjoin/common-session",
-  }
+}
 
+file { '/etc/pam.d/common-auth':
+  ensure => file,
+  owner  => 'root',
+  group  => 'root',
+  mode   => '0644',
+  source => 'puppet:///modules/atomia/adjoin/common-auth',
+}
 
-  }
+file { '/etc/pam.d/common-session':
+  ensure => file,
+  owner  => 'root',
+  group  => 'root',
+  mode   => '0644',
+  source => 'puppet:///modules/atomia/adjoin/common-session',
+}
 
-define atomia::adjoin_config::register ($content="", $order='10') {
+define atomia::adjoin_config::register ($content='', $order='10') {
   $factfile = '/etc/facter/facts.d/ad_servers.txt'
 
   @@concat::fragment {"active_directory_${content}":
-      target => $factfile,
-      content => "${content} ",
-      tag => 'ad_servers',
-      order => 3
-    }
+    target  => $factfile,
+    content => "${content} ",
+    tag     => 'ad_servers',
+    order   => 3
+  }
 }

--- a/manifests/apache_agent.pp
+++ b/manifests/apache_agent.pp
@@ -35,344 +35,362 @@
 ##### apache_modules_to_enable(advanced): ^[a-z0-9_-]+(,[a-z0-9_-]+)$
 
 class atomia::apache_agent (
-	$username			= "automationserver",
-	$password,
-	$atomia_clustered		= 1,
-	$should_have_pa_apache		= 1,
-	$content_share_nfs_location	= '',
-	$config_share_nfs_location	= '',
-	$use_nfs3			= 1,
-	$cluster_ip,
-	$apache_agent_ip		= $fqdn,
-	$maps_path			= "/storage/configuration/maps",
-	$should_have_php_farm		= 0,
-	$php_versions			= "5.4.45,5.5.29,5.6.10",
-	$php_extension_packages		= "php5-gd,php5-imagick,php5-sybase,php5-mysql,php5-odbc,php5-curl,php5-pgsql",
-	$apache_modules_to_enable	= "rewrite,userdir,fcgid,suexec,expires,headers,deflate,include"
+  $username                   = 'automationserver',
+  $password,
+  $atomia_clustered           = 1,
+  $should_have_pa_apache      = 1,
+  $content_share_nfs_location = '',
+  $config_share_nfs_location  = '',
+  $use_nfs3                   = 1,
+  $cluster_ip,
+  $apache_agent_ip            = $fqdn,
+  $maps_path                  = '/storage/configuration/maps',
+  $should_have_php_farm       = 0,
+  $php_versions               = '5.4.45,5.5.29,5.6.10',
+  $php_extension_packages     = 'php5-gd,php5-imagick,php5-sybase,php5-mysql,php5-odbc,php5-curl,php5-pgsql',
+  $apache_modules_to_enable   = 'rewrite,userdir,fcgid,suexec,expires,headers,deflate,include'
 ) {
 
-	if $lsbdistrelease == "14.04" {
-		$pa_conf_available_path = "/etc/apache2/conf-available"
-		$pa_conf_file = "atomia-pa-apache.conf.ubuntu.1404"
-		$pa_site = "000-default.conf"
-		$pa_site_enabled = "000-default.conf"
-	} else {
-		$pa_conf_available_path = "/etc/apache2/conf.d"
-		$pa_conf_file = "atomia-pa-apache.conf.ubuntu"
-		$pa_site = "default"
-		$pa_site_enabled = "000-default"
-	}
+  if $::lsbdistrelease == '14.04' {
+    $pa_conf_available_path = '/etc/apache2/conf-available'
+    $pa_conf_file           = 'atomia-pa-apache.conf.ubuntu.1404'
+    $pa_site                = '000-default.conf'
+    $pa_site_enabled        = '000-default.conf'
+  } else {
+    $pa_conf_available_path = '/etc/apache2/conf.d'
+    $pa_conf_file           = 'atomia-pa-apache.conf.ubuntu'
+    $pa_site                = 'default'
+    $pa_site_enabled        = '000-default'
+  }
 
-	if $should_have_pa_apache == "1" {
-		package { atomia-pa-apache:
-			ensure	=> present,
-			require	=> Package["apache2"],
-		}
-	}
+  if $should_have_pa_apache == '1' {
+    package { 'atomia-pa-apache':
+      ensure  => present,
+      require => Package['apache2'],
+    }
+  }
 
-    if($operatingsystem == 'CloudLinux') {
-        exec { 'add epel repo':
-            command => '/usr/bin/rpm -Uhv http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm',
-        }    
-            
-        $packages_to_install = [
-            "atomiastatisticscopy", "httpd"
-        ]        
-    } else {
-        $packages_to_install = [
-            "atomiastatisticscopy", "libapache2-mod-fcgid-atomia", "apache2-suexec-custom-cgroups-atomia",
-            "php5-cgi", "libexpat1", "cgroup-bin"
-        ]
-        
-        if !defined(Package['apache2']) {
-		    package { apache2: ensure => present }
-	    }
+  if($::operatingsystem == 'CloudLinux') {
+    exec { 'add epel repo':
+      command => '/usr/bin/rpm -Uhv http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm',
     }
 
-	package { $packages_to_install: ensure => installed }
+    $packages_to_install = [
+      'atomiastatisticscopy', 'httpd'
+    ]
+  } else {
+    $packages_to_install = [
+      'apache2-suexec-custom-cgroups-atomia',
+      'atomiastatisticscopy',
+      'cgroup-bin',
+      'libapache2-mod-fcgid-atomia',
+      'libexpat1',
+      'php5-cgi',
+    ]
 
-	$php_package_array = split($php_extension_packages, ',')
-	package { $php_package_array: ensure => installed }
-	
-	if $content_share_nfs_location == '' {
-		$internal_zone = hiera('atomia::internaldns::zone_name','')
-		
-		package { 'glusterfs-client': ensure => present, }
-		
-		if !defined(File["/storage"]) {
-			file { "/storage":
-			ensure => directory,
-			}
-		}
-		
-		fstab::mount { '/storage/content':
-			ensure  => 'mounted',
-			device  => "gluster.${internal_zone}:/web_volume",
-			options => 'defaults,_netdev',
-			fstype  => 'glusterfs',
-			require => [Package['glusterfs-client'],File["/storage"]],
-		}	
-		fstab::mount { '/storage/configuration':
-			ensure  => 'mounted',
-			device  => "gluster.${internal_zone}:/config_volume",
-			options => 'defaults,_netdev',
-			fstype  => 'glusterfs',
-			require => [ Package['glusterfs-client'],File["/storage"]],
-		}			
-	}
-	else
-	{
-		atomia::nfsmount { 'mount_content':
-			use_nfs3		 => 1,
-			mount_point  => '/storage/content',
-			nfs_location => $content_share_nfs_location
-		}
+    if !defined(Package['apache2']) {
+      package { 'apache2': ensure => present }
+    }
+  }
 
-		atomia::nfsmount { 'mount_configuration':
-			use_nfs3		 => 1,
-			mount_point  => '/storage/configuration',
-			nfs_location => $config_share_nfs_location
-		}
-	}
-	 
-	if $should_have_pa_apache == 1 {
-		file { "/usr/local/apache-agent/settings.cfg":
-			owner		=> root,
-			group		=> root,
-			mode		=> "440",
-			content => template("atomia/apache_agent/settings.erb"),
-			require => Package["atomia-pa-apache"],
-		}
-	}
+  package { $packages_to_install: ensure => installed }
 
-	file { "${$pa_conf_available_path}/${$pa_conf_file}":
-			ensure	=> present,
-			content => template("atomia/apache_agent/atomia-pa-apache.conf.erb"),
-			require => [Package["atomia-pa-apache"]],
-			notify	=> Service["apache2"],
-	}
+  $php_package_array = split($php_extension_packages, ',')
+  package { $php_package_array: ensure => installed }
 
-	file { "/etc/statisticscopy.conf":
-		owner	=> root,
-		group	=> root,
-		mode	=> "440",
-		content	=> template("atomia/apache_agent/statisticscopy.erb"),
-		require	=> Package["atomiastatisticscopy"],
-	}
+  if $content_share_nfs_location == '' {
+    $internal_zone = hiera('atomia::internaldns::zone_name','')
 
-	file { "/var/log/httpd":
-		owner	=> root,
-		group	=> root,
-		mode	=> "600",
-		ensure	=> directory,
-		before	=> Service["apache2"],
-	}
+    package { 'glusterfs-client': ensure => present, }
 
-	file { "/var/www/cgi-wrappers": mode => "755", }
+    if !defined(File['/storage']) {
+      file { '/storage':
+        ensure => directory,
+      }
+    }
 
-	file { "$maps_path":
-		owner	=> root,
-		group	=> www-data,
-		mode	=> "2750",
-		ensure	=> directory,
-		recurse => true,
-	}
+    fstab::mount { '/storage/content':
+      ensure  => 'mounted',
+      device  => "gluster.${internal_zone}:/web_volume",
+      options => 'defaults,_netdev',
+      fstype  => 'glusterfs',
+      require => [Package['glusterfs-client'],File['/storage']],
+    }
+    fstab::mount { '/storage/configuration':
+      ensure  => 'mounted',
+      device  => "gluster.${internal_zone}:/config_volume",
+      options => 'defaults,_netdev',
+      fstype  => 'glusterfs',
+      require => [ Package['glusterfs-client'],File['/storage']],
+    }
+  }
+  else
+  {
+    atomia::nfsmount { 'mount_content':
+      use_nfs3     => 1,
+      mount_point  => '/storage/content',
+      nfs_location => $content_share_nfs_location
+    }
 
-	file { "/storage/configuration/apache":
-		owner	=> root,
-		group	=> www-data,
-		mode	=> "2750",
-		ensure	=> directory,
-		recurse	=> true,
-	}
+    atomia::nfsmount { 'mount_configuration':
+      use_nfs3     => 1,
+      mount_point  => '/storage/configuration',
+      nfs_location => $config_share_nfs_location
+    }
+  }
 
-	$maps_to_ensure = [
-		"$maps_path/frmrs.map", "$maps_path/parks.map", "$maps_path/phpvr.map", "$maps_path/redrs.map", "$maps_path/sspnd.map",
-		"$maps_path/users.map", "$maps_path/vhost.map"
-	]
+  if $should_have_pa_apache == 1 {
+    file { '/usr/local/apache-agent/settings.cfg':
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0440',
+      content => template('atomia/apache_agent/settings.erb'),
+      require => Package['atomia-pa-apache'],
+    }
+  }
 
-	file { $maps_to_ensure:
-		owner	=> root,
-		group	=> www-data,
-		mode	=> "440",
-		ensure	=> present,
-		require => File["$maps_path"],
-	}
+  file { "${pa_conf_available_path}/${pa_conf_file}":
+    ensure  => present,
+    content => template('atomia/apache_agent/atomia-pa-apache.conf.erb'),
+    require => [Package['atomia-pa-apache']],
+    notify  => Service['apache2'],
+  }
+
+  file { '/etc/statisticscopy.conf':
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0440',
+    content => template('atomia/apache_agent/statisticscopy.erb'),
+    require => Package['atomiastatisticscopy'],
+  }
+
+  file { '/var/log/httpd':
+    ensure => directory,
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0600',
+    before => Service['apache2'],
+  }
+
+  file { '/var/www/cgi-wrappers': mode => '0755', }
+
+  file { $maps_path:
+    ensure  => directory,
+    owner   => 'root',
+    group   => 'www-data',
+    mode    => '2750',
+    recurse => true,
+  }
+
+  file { '/storage/configuration/apache':
+    ensure  => directory,
+    owner   => 'root',
+    group   => 'www-data',
+    mode    => '2750',
+    recurse => true,
+  }
+
+  $maps_to_ensure = [
+    "${maps_path}/frmrs.map", "${maps_path}/parks.map", "${maps_path}/phpvr.map", "${maps_path}/redrs.map", "${maps_path}/sspnd.map",
+    "${maps_path}/users.map", "${maps_path}/vhost.map"
+  ]
+
+  file { $maps_to_ensure:
+    ensure  => present,
+    owner   => 'root',
+    group   => 'www-data',
+    mode    => '0440',
+    require => File[$maps_path],
+  }
 
 
-	if !defined(File["/etc/apache2/sites-enabled/${$pa_site_enabled}"]) {
-		file { "/etc/apache2/sites-enabled/${$pa_site_enabled}":
-			ensure	=> absent,
-			require => Package["apache2"],
-			notify	=> Service["apache2"],
-		}
-	}
+  if !defined(File["/etc/apache2/sites-enabled/${pa_site_enabled}"]) {
+    file { "/etc/apache2/sites-enabled/${pa_site_enabled}":
+      ensure  => absent,
+      require => Package['apache2'],
+      notify  => Service['apache2'],
+    }
+  }
 
-	if !defined(File["/etc/apache2/sites-available/${$pa_site}"]) {
-		file { "/etc/apache2/sites-available/${$pa_site}":
-			ensure	=> absent,
-			require	=> Package["apache2"],
-			notify	=> Service["apache2"],
-		}
-	}
+  if !defined(File["/etc/apache2/sites-available/${pa_site}"]) {
+    file { "/etc/apache2/sites-available/${pa_site}":
+      ensure  => absent,
+      require => Package['apache2'],
+      notify  => Service['apache2'],
+    }
+  }
 
-	file { "${$pa_conf_available_path}/001-custom-errors":
-		owner		=> root,
-		group		=> root,
-		mode		=> "444",
-		source		=> "puppet:///modules/atomia/apache_agent/001-custom-errors",
-		require		=> Package["apache2"],
-		notify		=> Service["apache2"],
-	}
+  file { "${pa_conf_available_path}/001-custom-errors":
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0444',
+    source  => 'puppet:///modules/atomia/apache_agent/001-custom-errors',
+    require => Package['apache2'],
+    notify  => Service['apache2'],
+  }
 
-	if $lsbdistrelease == "14.04" {
-		file { "/etc/apache2/conf-enabled/001-custom-errors.conf":
-		ensure	=> link,
-		target	=> "../conf-available/001-custom-errors",
-		require	=> File["${$pa_conf_available_path}/001-custom-errors"],
-		notify	=> Service["apache2"],
-		}
-	}
+  if $::lsbdistrelease == '14.04' {
+    file { '/etc/apache2/conf-enabled/001-custom-errors.conf':
+      ensure  => link,
+      target  => '../conf-available/001-custom-errors',
+      require => File["${pa_conf_available_path}/001-custom-errors"],
+      notify  => Service['apache2'],
+    }
+  }
 
-	file { "/etc/apache2/suexec/www-data":
-		owner		=> root,
-		group		=> root,
-		mode		=> "444",
-		source		=> "puppet:///modules/atomia/apache_agent/suexec-conf",
-		require		=> [Package["apache2"], Package["apache2-suexec-custom-cgroups-atomia"]],
-		notify	=> Service["apache2"],
-	}
+  file { '/etc/apache2/suexec/www-data':
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0444',
+    source  => 'puppet:///modules/atomia/apache_agent/suexec-conf',
+    require => [Package['apache2'], Package['apache2-suexec-custom-cgroups-atomia']],
+    notify  => Service['apache2'],
+  }
 
-	file { "/etc/cgconfig.conf":
-		owner	=> root,
-		group	=> root,
-		mode	=> "444",
-		source	=> "puppet:///modules/atomia/apache_agent/cgconfig.conf",
-		require	=> [Package["cgroup-bin"]],
-	}
+  file { '/etc/cgconfig.conf':
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0444',
+    source  => 'puppet:///modules/atomia/apache_agent/cgconfig.conf',
+    require => [Package['cgroup-bin']],
+  }
 
-	file { "/storage/configuration/php_session_path":
-		ensure	=> directory,
-		owner	=> root,
-		group	=> root,
-		mode	=> "1733",
-		require	=> Package["php5-cgi"],
-	}
+  file { '/storage/configuration/php_session_path':
+    ensure  => directory,
+    owner   => 'root',
+    group   => 'root',
+    mode    => '1733',
+    require => Package['php5-cgi'],
+  }
 
-	file { "/storage/configuration/php.ini":
-		replace	=> "no",
-		ensure	=> present,
-		source	=> "puppet:///modules/atomia/apache_agent/php.ini",
-		owner	=> root,
-		group	=> root,
-		mode	=> "644",
-	}
+  file { '/storage/configuration/php.ini':
+    ensure  => present,
+    replace => 'no',
+    source  => 'puppet:///modules/atomia/apache_agent/php.ini',
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+  }
 
-	file { "/etc/php5/cgi/php.ini":
-		ensure	=> link,
-		target	=> "/storage/configuration/php.ini",
-		require	=> [File["/storage/configuration/php.ini"], Package["php5-cgi"]],
-	}
+  file { '/etc/php5/cgi/php.ini':
+    ensure  => link,
+    target  => '/storage/configuration/php.ini',
+    require => [File['/storage/configuration/php.ini'], Package['php5-cgi']],
+  }
 
-	if $should_have_pa_apache == 1 {
-		service { atomia-pa-apache:
-			name		=> apache-agent,
-			enable		=> true,
-			ensure		=> running,
-			hasstatus	=> false,
-			pattern		=> "python /etc/init.d/apache-agent start",
-			subscribe	=> [Package["atomia-pa-apache"], File["/usr/local/apache-agent/settings.cfg"]],
-		}
-	}
-	
-	
-	$php_versions_array = split($php_versions, ',')
-	arrayPHP { $php_versions_array: }
-	
-	if ($should_have_php_farm == 1) and ($lsbdistrelease == "14.04") {
+  if $should_have_pa_apache == 1 {
+    service { 'atomia-pa-apache':
+      ensure    => running,
+      name      => apache-agent,
+      enable    => true,
+      hasstatus => false,
+      pattern   => 'python /etc/init.d/apache-agent start',
+      subscribe => [Package['atomia-pa-apache'], File['/usr/local/apache-agent/settings.cfg']],
+    }
+  }
 
-		$phpcompilepackages = [ git, libxml2, libxml2-dev, libssl-dev, libcurl4-openssl-dev, pkg-config, libicu-dev, libmcrypt-dev, php5-dev, libgeoip-dev, libmagickwand-dev, libjpeg-dev, libpng12-dev, libmysqlclient-dev ]
 
-		package { $phpcompilepackages:
-			ensure	=> "installed",
-			require	=> Package["libapache2-mod-fcgid-atomia"],
-		}
+  $php_versions_array = split($php_versions, ',')
+  arrayPHP { $php_versions_array: }
 
-		exec { "clone_phpfarm_repo" :
-			command	=> "/usr/bin/git clone git://git.code.sf.net/p/phpfarm/code /opt/phpfarm",
-			unless	=> "/usr/bin/test -f /opt/phpfarm/src/options.sh",
-			require	=> [Package["libapache2-mod-fcgid-atomia"], Package["php5-dev"], Package["git"]],
-		}
+  if ($should_have_php_farm == 1) and ($::lsbdistrelease == '14.04') {
 
-		file { "/opt/phpfarm/src/options.sh":
-			owner	=> root,
-			group	=> root,
-			mode	=> "755",
-			source	=> "puppet:///modules/atomia/apache_agent/php-options.sh",
-			require	=> Exec["clone_phpfarm_repo"],
-		}
+    $phpcompilepackages = [
+      'git',
+      'libcurl4-openssl-dev',
+      'libgeoip-dev',
+      'libicu-dev',
+      'libjpeg-dev',
+      'libmagickwand-dev',
+      'libmcrypt-dev',
+      'libmysqlclient-dev',
+      'libpng12-dev',
+      'libssl-dev',
+      'libxml2',
+      'libxml2-dev',
+      'php5-dev',
+      'pkg-config',
+    ]
 
-		$php_branches_array = extract_major_minor($php_versions_array)
+    package { $phpcompilepackages:
+      ensure  => 'installed',
+      require => Package['libapache2-mod-fcgid-atomia'],
+    }
 
-		file { "/etc/apache2/conf/phpversions.conf":
-			owner	=> root,
-			group	=> root,
-			mode	=> "644",
-			content	=> template("atomia/apache_agent/phpversions.erb"),
-			require => [Package["atomia-pa-apache"]],
-			notify	=> Service["apache2"],
-		}
-	}
+    exec { 'clone_phpfarm_repo' :
+      command => '/usr/bin/git clone git://git.code.sf.net/p/phpfarm/code /opt/phpfarm',
+      unless  => '/usr/bin/test -f /opt/phpfarm/src/options.sh',
+      require => [Package['libapache2-mod-fcgid-atomia'], Package['php5-dev'], Package['git']],
+    }
 
-	if !defined(Service['apache2']) {
-		service { apache2:
-			name	=> apache2,
-			enable	=> true,
-			ensure	=> running,
-		}
-	}
+    file { '/opt/phpfarm/src/options.sh':
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0755',
+      source  => 'puppet:///modules/atomia/apache_agent/php-options.sh',
+      require => Exec['clone_phpfarm_repo'],
+    }
 
-	if !defined(Exec['force-reload-apache']) {
-		exec { "force-reload-apache":
-			refreshonly	=> true,
-			before		=> Service["apache2"],
-			command		=> "/etc/init.d/apache2 force-reload",
-		}
-	}
+    $php_branches_array = extract_major_minor($php_versions_array)
 
-	$apache_modules_to_enable_array = split($apache_modules_to_enable, ',')
-	apacheModuleToEnable { $apache_modules_to_enable_array: }
+    file { '/etc/apache2/conf/phpversions.conf':
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0644',
+      content => template('atomia/apache_agent/phpversions.erb'),
+      require => [Package['atomia-pa-apache']],
+      notify  => Service['apache2'],
+    }
+  }
+
+  if !defined(Service['apache2']) {
+    service { 'apache2':
+      ensure => running,
+      enable => true,
+    }
+  }
+
+  if !defined(Exec['force-reload-apache']) {
+    exec { 'force-reload-apache':
+      refreshonly => true,
+      before      => Service['apache2'],
+      command     => '/etc/init.d/apache2 force-reload',
+    }
+  }
+
+  $apache_modules_to_enable_array = split($apache_modules_to_enable, ',')
+  apacheModuleToEnable { $apache_modules_to_enable_array: }
 }
 
 define arrayPHP {
-	$php_version = $name
-	# Compile PHP and create wrappers 
-	exec { "compile_php_${php_version}" :
-		command	=> "/opt/phpfarm/src/compile.sh ${$php_version}",
-		creates	=> "/opt/phpfarm/inst/bin/php-${$php_version}",
-		timeout	=> 1800,
-		onlyif	=> "/usr/bin/test -f /opt/phpfarm/src/options.sh",
-		require	=> Package["libapache2-mod-fcgid-atomia"],
-	}
-	exec {"check_php_install_${php_version}":
-		command	=> "/bin/sh -c '(/opt/phpfarm/inst/bin/php-${$php_version} --version | grep built) && touch /opt/phpfarm/inst/php-${$php_version}.tested'",
-		creates	=> "/opt/phpfarm/inst/php-${$php_version}.tested",
-		onlyif	=> "/usr/bin/test -f /opt/phpfarm/inst/bin/php-${$php_version}",
-		require	=> Exec["compile_php_${php_version}"]
-	}
-	file { "/var/www/cgi-wrappers/php-fcgid-wrapper-${php_version}":
-		owner		=> root,
-		group		=> root,
-		mode		=> "555",
-		content		=> template("atomia/apache_agent/php-fcgid-wrapper-custom.erb"),
-		require		=> [Exec["compile_php_${php_version}"], Exec["check_php_install_${php_version}"]],
-	}
+  $php_version = $name
+  # Compile PHP and create wrappers
+  exec { "compile_php_${php_version}" :
+    command => "/opt/phpfarm/src/compile.sh ${php_version}",
+    creates => "/opt/phpfarm/inst/bin/php-${php_version}",
+    timeout => 1800,
+    onlyif  => '/usr/bin/test -f /opt/phpfarm/src/options.sh',
+    require => Package['libapache2-mod-fcgid-atomia'],
+  }
+  exec {"check_php_install_${php_version}":
+    command => "/bin/sh -c '(/opt/phpfarm/inst/bin/php-${php_version} --version | grep built) && touch /opt/phpfarm/inst/php-${php_version}.tested'",
+    creates => "/opt/phpfarm/inst/php-${php_version}.tested",
+    onlyif  => "/usr/bin/test -f /opt/phpfarm/inst/bin/php-${php_version}",
+    require => Exec["compile_php_${php_version}"]
+  }
+  file { "/var/www/cgi-wrappers/php-fcgid-wrapper-${php_version}":
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0555',
+    content => template('atomia/apache_agent/php-fcgid-wrapper-custom.erb'),
+    require => [Exec["compile_php_${php_version}"], Exec["check_php_install_${php_version}"]],
+  }
 }
 
 define apacheModuleToEnable {
-	exec { "/usr/sbin/a2enmod $name":
-		unless	=> "/usr/bin/test -f /etc/apache2/mods-enabled/$name.load",
-		require	=> Package["apache2"],
-		notify	=> Exec["force-reload-apache"],
-	}
+  exec { "/usr/sbin/a2enmod ${name}":
+    unless  => "/usr/bin/test -f /etc/apache2/mods-enabled/${name}.load",
+    require => Package['apache2'],
+    notify  => Exec['force-reload-apache'],
+  }
 }

--- a/manifests/apache_agent_cl.pp
+++ b/manifests/apache_agent_cl.pp
@@ -31,265 +31,268 @@
 ##### cloudlinux_agent_secret: %password
 
 class atomia::apache_agent_cl (
-	$username			= "automationserver",
-	$password,
-	$should_have_pa_apache		= 1,
-	$content_share_nfs_location	= '',
-	$config_share_nfs_location	= '',
-	$use_nfs3			= 1,
-	$cluster_ip,
-	$apache_agent_ip		= $fqdn,
-	$maps_path			= "/storage/configuration/maps",
-	$should_have_php_farm		= 0,
-	$apache_modules_to_enable	= "rewrite,userdir,fcgid,suexec,expires,headers,deflate,include",
-    $is_master  = 1,
-    $cloudlinux_agent_secret
+  $username                   = 'automationserver',
+  $password,
+  $should_have_pa_apache      = 1,
+  $content_share_nfs_location = '',
+  $config_share_nfs_location  = '',
+  $use_nfs3                   = 1,
+  $cluster_ip,
+  $apache_agent_ip            = $::fqdn,
+  $maps_path                  = '/storage/configuration/maps',
+  $should_have_php_farm       = 0,
+  $apache_modules_to_enable   = 'rewrite,userdir,fcgid,suexec,expires,headers,deflate,include',
+  $is_master                  = 1,
+  $cloudlinux_agent_secret
 ) {
 
 
-	if $content_share_nfs_location == '' {
-		$internal_zone = hiera('atomia::internaldns::zone_name','')
-		
-		package { 'glusterfs-client': ensure => present, }
-		
-		if !defined(File["/storage"]) {
-			file { "/storage":
-			ensure => directory,
-			}
-		}
-		
-		fstab::mount { '/storage/content':
-			ensure  => 'mounted',
-			device  => "gluster.${internal_zone}:/web_volume",
-			options => 'defaults,_netdev',
-			fstype  => 'glusterfs',
-			require => [Package['glusterfs-client'],File["/storage"]],
-		}	
-		fstab::mount { '/storage/configuration':
-			ensure  => 'mounted',
-			device  => "gluster.${internal_zone}:/config_volume",
-			options => 'defaults,_netdev',
-			fstype  => 'glusterfs',
-			require => [ Package['glusterfs-client'],File["/storage"]],
-		}			
-	}
-	else
-	{
-		atomia::nfsmount { 'mount_content':
-			use_nfs3		 => 1,
-			mount_point  => '/storage/content',
-			nfs_location => $content_share_nfs_location
-		}
+  if $content_share_nfs_location == '' {
+    $internal_zone = hiera('atomia::internaldns::zone_name','')
 
-		atomia::nfsmount { 'mount_configuration':
-			use_nfs3		 => 1,
-			mount_point  => '/storage/configuration',
-			nfs_location => $config_share_nfs_location
-		}
-	}
+    package { 'glusterfs-client': ensure => present, }
 
-
-	if $should_have_pa_apache == "1" {
-		package { atomia-pa-apache:
-			ensure	=> present,
-			require	=> [Package["httpd"], Package["cronolog"], Package["atomia-python-ZSI"], Package["mod_ssl"] ],
-		}
-        
-        package { 'nodejs':
-            ensure  => present,
-            require => Exec['add epel repo'],
-        }
-        package { 'atomia-cloudlinux-agent':
-            ensure  => present,
-            require => Package['nodejs'],
-        }
-        
-        service { 'atomia-cloudlinux-agent':
-            ensure  => running
-        }
-        
-        exec { 'sync php versions':
-            command => "/usr/bin/curl -X PUT -H \"Authorization: ${cloudlinux_agent_secret}\" http://localhost:8000/php/sync -v",
-            require => [Package['atomia-cloudlinux-agent'], Exec['install altphp']],
-        }
-	}
-
-    exec { 'add epel repo':
-        command => '/usr/bin/rpm -Uhv http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm',
-        unless => "/usr/bin/rpm -qi epel-release | /bin/grep  -c 'Build Date'"
-    }    
-        
-    $packages_to_install = [
-        "atomiastatisticscopy", "httpd", "cronolog", "atomia-python-ZSI", "mod_ssl"
-    ]        
-
-	package { $packages_to_install: ensure => installed,
-        require => Exec['add epel repo'], 
-    }
-    
-    service { 'httpd':
-        ensure  => running,
-    }
-    
-    file { "/etc/httpd/conf.d/atomia-pa-apache.conf":
-			ensure	=> present,
-			content => template("atomia/apache_agent/atomia-pa-apache-cl.conf.erb"),
-			require => [Package["atomia-pa-apache"]],
-			notify	=> Service["httpd"],
-	}
-    
-    # Install Cagefs
-    package { cagefs:
-        ensure => present,
-        notify => Exec['init cagefs']
-    }
-    
-    exec { 'init cagefs':
-        command => '/usr/sbin/cagefsctl --init',
-        require => Package['cagefs'],
-        refreshonly => true,
-        notify  => Exec['enable cagefs']
-    }
-    
-    exec { 'enable cagefs':
-        command => '/usr/sbin/cagefsctl --disable-all',
-        require => Package['cagefs'],
-        refreshonly => true
-    }
-    
-    # Install alt-php
-    package { 'lvemanager': ensure => installed }
-    
-    exec { 'install altphp':
-        command => '/usr/bin/yum -y groupinstall alt-php',
-        timeout     => 1800,
-        unless => '/usr/bin/rpm -qa | /bin/grep -c alt-php70',
-        require => [Package['lvemanager'], Package['cagefs']],
-    }
-    
-    file { '/etc/httpd/conf/phpversions.conf':
-        ensure => present,
-        require => Package['httpd'],
-    }
-    
-    # Install mod_lsapi
-    exec { 'install mod_lsapi':
-        command => "/usr/bin/yum -y install liblsapi liblsapi-devel mod_lsapi gcc gcc-c++ cmake httpd-devel --enablerepo=cloudlinux-updates-testing",
-        unless => '/usr/bin/rpm -qa | /bin/grep -c liblsapi',
-        notify => Exec['setup mod_lsapi']
-    }
-    
-    exec { 'setup mod_lsapi':
-        command => "/usr/bin/switch_mod_lsapi --setup",
-        refreshonly => true
-    }
-    
-    file { "/etc/httpd/conf.d/lsapi.conf":
-        owner		=> root,
-        group		=> root,
-        mode		=> "0644",
-        content => template("atomia/apache_agent/lsapi.conf.erb"),
-        require => Exec['install mod_lsapi'],
-        notify  => Service['httpd']
-    }
-    
-   # Install mod_hostinglimits
-   package { 'mod_hostinglimits' :
-        ensure => present,
-        require => Package['httpd']
-   }
-   
-    file { "/etc/httpd/conf.d/modhostinglimits.conf":
-        owner		=> root,
-        group		=> root,
-        mode		=> "0644",
-        content => template("atomia/apache_agent/modhostinglimits.conf.erb"),
-        require => Package['mod_hostinglimits'],
-        notify  => Service['httpd']
-    }
-    
-    # CloudLinux shared configuration
-    file { '/storage/configuration/cloudlinux':
-        owner   => root,
-        group   => root,
-        mode    => '0701',
-        ensure  => directory,
+    if !defined(File['/storage']) {
+      file { '/storage':
+        ensure => directory,
+      }
     }
 
-    file { '/storage/configuration/cloudlinux/users.enabled':
-        owner   => root,
-        group   => root,
-        mode    => '0701',
-        ensure  => directory,
-        require => File['/storage/configuration/cloudlinux']
-    }   
-   
-    file { '/etc/cagefs/users.enabled':
-        ensure => 'link',
-        target => '/storage/configuration/cloudlinux/users.enabled',
-        require => File['/storage/configuration/cloudlinux'],
-        force   => true,
+    fstab::mount { '/storage/content':
+      ensure  => 'mounted',
+      device  => "gluster.${internal_zone}:/web_volume",
+      options => 'defaults,_netdev',
+      fstype  => 'glusterfs',
+      require => [Package['glusterfs-client'],File['/storage']],
     }
-    
-    file { '/storage/configuration/cloudlinux/cagefs_var':
-        owner   => root,
-        group   => root,
-        mode    => '0751',
-        ensure  => directory,
-        require => File['/storage/configuration/cloudlinux']
-    }       
+    fstab::mount { '/storage/configuration':
+      ensure  => 'mounted',
+      device  => "gluster.${internal_zone}:/config_volume",
+      options => 'defaults,_netdev',
+      fstype  => 'glusterfs',
+      require => [ Package['glusterfs-client'],File['/storage']],
+    }
+  }
+  else
+  {
+    atomia::nfsmount { 'mount_content':
+      use_nfs3     => 1,
+      mount_point  => '/storage/content',
+      nfs_location => $content_share_nfs_location,
+    }
 
-    file { '/var/cagefs':
-        ensure => 'link',
-        target => '/storage/configuration/cloudlinux/cagefs_var',
-        require => [File['/storage/configuration/cloudlinux/cagefs_var'], Exec['init cagefs']] ,
-        force   => true,
-    }    
-    
-    file { '/storage/configuration/cloudlinux/cagefs_container':
-        owner   => root,
-        group   => root,
-        mode    => '0755',
-        ensure  => directory,
-        require => File['/storage/configuration/cloudlinux']
+    atomia::nfsmount { 'mount_configuration':
+      use_nfs3     => 1,
+      mount_point  => '/storage/configuration',
+      nfs_location => $config_share_nfs_location,
     }
-    
-    file { '/etc/container':
-        ensure  => 'link',
-        target  => '/storage/configuration/cloudlinux/cagefs_container',
-        require => [File['/storage/configuration/cloudlinux/cagefs_container'], Exec['init cagefs']],
-        force   => true,
-    }
-      
-	file { "$maps_path":
-		owner	=> root,
-		group	=> apache,
-		mode	=> "2750",
-		ensure	=> directory,
-		recurse => true,
-	}
-    
-    file { '/storage/configuration/cloudlinux/cagefs_container/ve.cfg':
-        owner   => root,
-        group   => root,
-        mode    => '0644',
-        ensure  => file,
-        replace => 'no',
-        content => template("atomia/apache_agent/ve.cfg.erb"),
-        require => File['/etc/container']
-    }    
-    
-    $maps_to_ensure = [
-        "$maps_path/frmrs.map", "$maps_path/parks.map", "$maps_path/phpvr.map", "$maps_path/redrs.map", "$maps_path/sspnd.map",
-        "$maps_path/users.map", "$maps_path/vhost.map", "$maps_path/proxy.map"
-	]
+  }
 
-	file { $maps_to_ensure:
-		owner	=> root,
-		group	=> apache,
-		mode	=> "440",
-		ensure	=> present,
-		require => File["$maps_path"],
-	}
-    
+
+  if $should_have_pa_apache == '1' {
+    package { 'atomia-pa-apache':
+      ensure  => present,
+      require => [Package['httpd'], Package['cronolog'], Package['atomia-python-ZSI'], Package['mod_ssl'] ],
+    }
+
+    package { 'nodejs':
+      ensure  => present,
+      require => Exec['add epel repo'],
+    }
+    package { 'atomia-cloudlinux-agent':
+      ensure  => present,
+      require => Package['nodejs'],
+    }
+
+    service { 'atomia-cloudlinux-agent':
+      ensure  => running
+    }
+
+    exec { 'sync php versions':
+      command => "/usr/bin/curl -X PUT -H \"Authorization: ${cloudlinux_agent_secret}\" http://localhost:8000/php/sync -v",
+      require => [Package['atomia-cloudlinux-agent'], Exec['install altphp']],
+    }
+  }
+
+  exec { 'add epel repo':
+    command => '/usr/bin/rpm -Uhv http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm',
+    unless  => "/usr/bin/rpm -qi epel-release | /bin/grep  -c 'Build Date'"
+  }
+
+  $packages_to_install = [
+    'atomiastatisticscopy', 'httpd', 'cronolog', 'atomia-python-ZSI', 'mod_ssl'
+  ]
+
+  package { $packages_to_install:
+    ensure  => installed,
+    require => Exec['add epel repo'],
+  }
+
+  service { 'httpd':
+    ensure  => running,
+  }
+
+  file { '/etc/httpd/conf.d/atomia-pa-apache.conf':
+    ensure  => present,
+    content => template('atomia/apache_agent/atomia-pa-apache-cl.conf.erb'),
+    require => Package['atomia-pa-apache'],
+    notify  => Service['httpd'],
+  }
+
+  # Install Cagefs
+  package { 'cagefs':
+    ensure => present,
+    notify => Exec['init cagefs'],
+  }
+
+  exec { 'init cagefs':
+    command     => '/usr/sbin/cagefsctl --init',
+    require     => Package['cagefs'],
+    refreshonly => true,
+    notify      => Exec['enable cagefs'],
+  }
+
+  exec { 'enable cagefs':
+    command     => '/usr/sbin/cagefsctl --disable-all',
+    require     => Package['cagefs'],
+    refreshonly => true,
+  }
+
+  # Install alt-php
+  package { 'lvemanager':
+    ensure => installed
+  }
+
+  exec { 'install altphp':
+    command => '/usr/bin/yum -y groupinstall alt-php',
+    timeout => 1800,
+    unless  => '/usr/bin/rpm -qa | /bin/grep -c alt-php70',
+    require => [Package['lvemanager'], Package['cagefs']],
+  }
+
+  file { '/etc/httpd/conf/phpversions.conf':
+    ensure  => present,
+    require => Package['httpd'],
+  }
+
+  # Install mod_lsapi
+  exec { 'install mod_lsapi':
+    command => '/usr/bin/yum -y install liblsapi liblsapi-devel mod_lsapi gcc gcc-c++ cmake httpd-devel --enablerepo=cloudlinux-updates-testing',
+    unless  => '/usr/bin/rpm -qa | /bin/grep -c liblsapi',
+    notify  => Exec['setup mod_lsapi']
+  }
+
+  exec { 'setup mod_lsapi':
+    command     => '/usr/bin/switch_mod_lsapi --setup',
+    refreshonly => true
+  }
+
+  file { '/etc/httpd/conf.d/lsapi.conf':
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    content => template('atomia/apache_agent/lsapi.conf.erb'),
+    require => Exec['install mod_lsapi'],
+    notify  => Service['httpd']
+  }
+
+  # Install mod_hostinglimits
+  package { 'mod_hostinglimits':
+    ensure  => present,
+    require => Package['httpd'],
+  }
+
+  file { '/etc/httpd/conf.d/modhostinglimits.conf':
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    content => template('atomia/apache_agent/modhostinglimits.conf.erb'),
+    require => Package['mod_hostinglimits'],
+    notify  => Service['httpd']
+  }
+
+  # CloudLinux shared configuration
+  file { '/storage/configuration/cloudlinux':
+    ensure => directory,
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0701',
+  }
+
+  file { '/storage/configuration/cloudlinux/users.enabled':
+    ensure  => directory,
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0701',
+    require => File['/storage/configuration/cloudlinux']
+  }
+
+  file { '/etc/cagefs/users.enabled':
+    ensure  => 'link',
+    target  => '/storage/configuration/cloudlinux/users.enabled',
+    require => File['/storage/configuration/cloudlinux'],
+    force   => true,
+  }
+
+  file { '/storage/configuration/cloudlinux/cagefs_var':
+    ensure  => directory,
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0751',
+    require => File['/storage/configuration/cloudlinux']
+  }
+
+  file { '/var/cagefs':
+    ensure  => 'link',
+    target  => '/storage/configuration/cloudlinux/cagefs_var',
+    require => [File['/storage/configuration/cloudlinux/cagefs_var'], Exec['init cagefs']],
+    force   => true,
+  }
+
+  file { '/storage/configuration/cloudlinux/cagefs_container':
+    ensure  => directory,
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0755',
+    require => File['/storage/configuration/cloudlinux']
+  }
+
+  file { '/etc/container':
+    ensure  => 'link',
+    target  => '/storage/configuration/cloudlinux/cagefs_container',
+    require => [File['/storage/configuration/cloudlinux/cagefs_container'], Exec['init cagefs']],
+    force   => true,
+  }
+
+  file { $maps_path:
+    ensure  => directory,
+    owner   => 'root',
+    group   => 'apache',
+    mode    => '2750',
+    recurse => true,
+  }
+
+  file { '/storage/configuration/cloudlinux/cagefs_container/ve.cfg':
+    ensure  => file,
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    replace => 'no',
+    content => template('atomia/apache_agent/ve.cfg.erb'),
+    require => File['/etc/container']
+  }
+
+  $maps_to_ensure = [
+    "${maps_path}/frmrs.map", "${maps_path}/parks.map", "${maps_path}/phpvr.map", "${maps_path}/redrs.map", "${maps_path}/sspnd.map",
+    "${maps_path}/users.map", "${maps_path}/vhost.map", "${maps_path}/proxy.map"
+  ]
+
+  file { $maps_to_ensure:
+    ensure  => present,
+    owner   => 'root',
+    group   => 'apache',
+    mode    => '0440',
+    require => File[$maps_path],
+  }
+
 }

--- a/manifests/apache_password_protect.pp
+++ b/manifests/apache_password_protect.pp
@@ -20,50 +20,50 @@
 
 
 class atomia::apache_password_protect ($username, $password) {
-  
-  file { "/etc/apache2":
+
+  file { '/etc/apache2':
     ensure => directory,
-    owner  => root,
-    group  => root,
-    mode   => "755",
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0755',
   }
 
-  file { "/etc/apache2/conf.d":
+  file { '/etc/apache2/conf.d':
     ensure  => directory,
-    owner   => root,
-    group   => root,
-    mode    => "755",
-    require => File["/etc/apache2"],
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0755',
+    require => File['/etc/apache2'],
   }
 
 
   htpasswd { $username:
-    cryptpasswd => ht_sha1($password),  
+    cryptpasswd => ht_sha1($password),
     target      => '/etc/apache2/htpasswd.conf',
-    require => File['/etc/apache2'],
-  }  
-  ->
-  file { "/etc/apache2/htpasswd.conf":
-    owner   => root,
-    group   => root,
-    mode    => "444",
-    require => File["/etc/apache2"],
+    require     => File['/etc/apache2'],
   }
-  
-  file { "/etc/apache2/conf.d/passwordprotect":
-    owner   => root,
-    group   => root,
-    mode    => "440",
-    source  => "puppet:///modules/atomia/apache_password_protect/passwordprotect",
-    require => File["/etc/apache2/conf.d"],
+->
+file { '/etc/apache2/htpasswd.conf':
+  owner   => 'root',
+  group   => 'root',
+  mode    => '0444',
+  require => File['/etc/apache2'],
+}
+
+file { '/etc/apache2/conf.d/passwordprotect':
+  owner   => 'root',
+  group   => 'root',
+  mode    => '0440',
+  source  => 'puppet:///modules/atomia/apache_password_protect/passwordprotect',
+  require => File['/etc/apache2/conf.d'],
+}
+
+if $::lsbdistrelease == '14.04' {
+  exec { 'create_link_24':
+    require => File['/etc/apache2/conf.d/passwordprotect'],
+    command => '/bin/ln -s /etc/apache2/conf.d/passwordprotect /etc/apache2/conf-enabled/passwordprotect.conf',
+    unless  => '/usr/bin/test -f /etc/apache2/conf-enabled/passwordprotect.conf',
   }
-  
-  if $lsbdistrelease == "14.04" {
-    exec { "create_link_24":
-    require => File["/etc/apache2/conf.d/passwordprotect"],
-    command => "/bin/ln -s /etc/apache2/conf.d/passwordprotect /etc/apache2/conf-enabled/passwordprotect.conf",
-    unless  => "/usr/bin/test -f /etc/apache2/conf-enabled/passwordprotect.conf",
-    }
-  }
+}
 }
 

--- a/manifests/atomia_database.pp
+++ b/manifests/atomia_database.pp
@@ -11,34 +11,34 @@
 ##### atomia_password(advanced): %password
 
 class atomia::atomia_database (
-	$atomia_user = "atomia",
-	$atomia_password,
-    $server_address = $fqdn
-	){
+  $atomia_user      = 'atomia',
+  $atomia_password,
+  $server_address   = $fqdn
+){
 
-    package { 'postgresql-contrib':
-        ensure  => present
-    }
-	class { 'postgresql::server':
-		ip_mask_allow_all_users    => '0.0.0.0/0',
-		listen_addresses           => '*',
-		ipv4acls                   => ['host all atomia 0.0.0.0/0 md5']
-	}
+  package { 'postgresql-contrib':
+    ensure  => present
+  }
+  class { 'postgresql::server':
+    ip_mask_allow_all_users => '0.0.0.0/0',
+    listen_addresses        => '*',
+    ipv4acls                => ['host all atomia 0.0.0.0/0 md5']
+  }
 
-	postgresql::server::role { 'atomia_postgresql_provisioning_user':
-		username => $atomia_user,
-		password_hash => postgresql_password($atomia_user, $atomia_password),
-		createdb => true,
-		createrole => true,
-		superuser => true
-	}
-    
-    postgresql::server::pg_hba_rule { 'allow network acces for atomia user':
-        description => "Open up postgresql for access for Atomia user",
-        type => 'host',
-        database => 'all',
-        user => $atomia_user,
-        address => '0.0.0.0/0',
-        auth_method => 'password',
-    }    
+  postgresql::server::role { 'atomia_postgresql_provisioning_user':
+    username      => $atomia_user,
+    password_hash => postgresql_password($atomia_user, $atomia_password),
+    createdb      => true,
+    createrole    => true,
+    superuser     => true
+  }
+
+  postgresql::server::pg_hba_rule { 'allow network acces for atomia user':
+    description => 'Open up postgresql for access for Atomia user',
+    type        => 'host',
+    database    => 'all',
+    user        => $atomia_user,
+    address     => '0.0.0.0/0',
+    auth_method => 'password',
+  }
 }

--- a/manifests/atomiadns_powerdns.pp
+++ b/manifests/atomiadns_powerdns.pp
@@ -15,80 +15,80 @@
 
 
 class atomia::atomiadns_powerdns (
-	$db_hostname	= "127.0.0.1",
-	$db_username	= "powerdns",
-	$db_password	= "",
+  $db_hostname  = '127.0.0.1',
+  $db_username  = 'powerdns',
+  $db_password  = '',
 ) {
-	$atomia_dns_url	= hiera('atomia::atomiadns::atomia_dns_url','http://$fqdn/atomiadns')
-	$agent_user	= hiera('atomia::atomiadns::agent_user','atomiadns')
-	$agent_password	= hiera('atomia::atomiadns::agent_password','')
-  	$ns_group	= hiera('atomia::atomiadns::ns_group','default')
-	$atomia_dns_extra_config = hiera('atomia::atomiadns::atomia_dns_extra_config','')
-	  
-	if !in_atomia_role("atomiadns") {
-		file { "/etc/atomiadns.conf":
-			owner   => root,
-			group   => root,
-			mode    => "444",
-			content => template("atomia/atomiadns_powerdns/atomiadns.conf.erb"),
-			notify => [ Service["atomiadns-powerdnssync"] ],
-		}
-	}
+  $atomia_dns_url          = hiera('atomia::atomiadns::atomia_dns_url','http://$fqdn/atomiadns')
+  $agent_user              = hiera('atomia::atomiadns::agent_user','atomiadns')
+  $agent_password          = hiera('atomia::atomiadns::agent_password','')
+  $ns_group                = hiera('atomia::atomiadns::ns_group','default')
+  $atomia_dns_extra_config = hiera('atomia::atomiadns::atomia_dns_extra_config','')
 
-	if $lsbdistrelease == "14.04" { 
-		$pdns_package = "pdns-server"
+  if !in_atomia_role('atomiadns') {
+    file { '/etc/atomiadns.conf':
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0444',
+      content => template('atomia/atomiadns_powerdns/atomiadns.conf.erb'),
+      notify  => [ Service['atomiadns-powerdnssync'] ],
+    }
+  }
 
-		package { pdns-backend-mysql:
-			ensure => present,
-			require => [ Package[$pdns_package] ]
-		}
-	} else {
-		$pdns_package = "pdns-static"
-	}
+  if $::lsbdistrelease == '14.04' {
+    $pdns_package = 'pdns-server'
 
-	package { $pdns_package:
-		ensure  => present
-	}
+    package { 'pdns-backend-mysql':
+      ensure  => present,
+      require => [ Package[$pdns_package] ]
+    }
+  } else {
+    $pdns_package = 'pdns-static'
+  }
 
-	service { pdns:
-		ensure    => running,
-		require   => [ Package[$pdns_package] ]
-	}
+  package { $pdns_package:
+    ensure  => present
+  }
 
-	package { atomiadns-powerdns-database:
-		require => [ File["/etc/atomiadns.conf"], Package[$pdns_package] ],
-		notify => [ Service["pdns"] ]
-	}
+  service { 'pdns':
+    ensure  => running,
+    require => [ Package[$pdns_package] ]
+  }
 
-	package { atomiadns-powerdnssync:
-  		ensure => present,
-		require => [ Package["atomiadns-powerdns-database"] ]
-	}
+  package { 'atomiadns-powerdns-database':
+    require => [ File['/etc/atomiadns.conf'], Package[$pdns_package] ],
+    notify  => [ Service['pdns'] ]
+  }
 
-	if $operatingsystem == "Ubuntu" {
-		package { dnsutils: ensure => present }
-	} else {
-		package { bind-utils: ensure => present }
-	}
+  package { 'atomiadns-powerdnssync':
+    ensure  => present,
+    require => [ Package['atomiadns-powerdns-database'] ]
+  }
 
-	service { atomiadns-powerdnssync:
-		name      => atomiadns-powerdnssync,
-		ensure    => running,
-		pattern   => ".*powerdnssync.*",
-		require   => [ Package["atomiadns-powerdns-database"], Package["atomiadns-powerdnssync"] ],
-	}
+  if $::operatingsystem == 'Ubuntu' {
+    package { 'dnsutils': ensure => present }
+  } else {
+    package { 'bind-utils': ensure => present }
+  }
 
-	if !in_atomia_role("atomiadns") {
-		exec { "add-server":
-			command => "/usr/bin/atomiapowerdnssync add_server \"$ns_group\" && service atomiadns-powerdnssync stop && service atomiadns-powerdnssync start && /usr/bin/atomiapowerdnssync full_reload_online",
-			require => [ Package["atomiadns-powerdnssync"] ],
-			unless  => ["/usr/bin/atomiapowerdnssync get_server"],
-		}
-	} else {
-		exec { "add-server":
-			command => "/usr/bin/atomiapowerdnssync add_server \"$ns_group\" && service atomiadns-powerdnssync stop && service atomiadns-powerdnssync start && /usr/bin/atomiapowerdnssync full_reload_online",
-			require => [ Package["atomiadns-powerdnssync"], Exec["add_nameserver_group"] ],
-			unless  => ["/usr/bin/atomiapowerdnssync get_server"],
-		}
-	}
+  service { 'atomiadns-powerdnssync':
+    ensure  => running,
+    name    => atomiadns-powerdnssync,
+    pattern => '.*powerdnssync.*',
+    require => [ Package['atomiadns-powerdns-database'], Package['atomiadns-powerdnssync'] ],
+  }
+
+  if !in_atomia_role('atomiadns') {
+    exec { 'add-server':
+      command => "/usr/bin/atomiapowerdnssync add_server \"${ns_group}\" && service atomiadns-powerdnssync stop && service atomiadns-powerdnssync start && /usr/bin/atomiapowerdnssync full_reload_online",
+      require => [ Package['atomiadns-powerdnssync'] ],
+      unless  => ['/usr/bin/atomiapowerdnssync get_server'],
+    }
+  } else {
+    exec { 'add-server':
+      command => "/usr/bin/atomiapowerdnssync add_server \"${ns_group}\" && service atomiadns-powerdnssync stop && service atomiadns-powerdnssync start && /usr/bin/atomiapowerdnssync full_reload_online",
+      require => [ Package['atomiadns-powerdnssync'], Exec['add_nameserver_group'] ],
+      unless  => ['/usr/bin/atomiapowerdnssync get_server'],
+    }
+  }
 }

--- a/manifests/atomiarepository.pp
+++ b/manifests/atomiarepository.pp
@@ -1,74 +1,74 @@
 class atomia::atomiarepository {
 
   # Workaround for Debian Jessie
-  if $operatingsystem == "Debian" {
+  if $::operatingsystem == 'Debian' {
     # Currently only supports Wheezy
-    $repo = "debian-wheezy wheezy main"
+    $repo = 'debian-wheezy wheezy main'
   }
   else {
-    $repo = "ubuntu-$lsbdistcodename $lsbdistcodename main"
+    $repo = "ubuntu-${::lsbdistcodename} ${::lsbdistcodename} main"
   }
 
-  if $osfamily == "RedHat" {  
-    if $operatingsystemmajrelease == "7" {
-        file { "/etc/pki/rpm-gpg/RPM-GPG-KEY-ATOMIA":
-            owner   => root,
-            group   => root,
-            mode    =>  06444,
-            source  => "puppet:///modules/atomia/repository/RPM-GPG-KEY-ATOMIA",
-        }
-        
-        file { "/etc/yum.repos.d/atomia-rhel7.repo": 
-            owner   => root,
-            group   => root,
-            mode    =>  06444,
-            source  => "puppet:///modules/atomia/repository/atomia-rhel7.repo", 
-            require => File["/etc/pki/rpm-gpg/RPM-GPG-KEY-ATOMIA"],       
-        }
+  if $::osfamily == 'RedHat' {
+    if $::operatingsystemmajrelease == '7' {
+      file { '/etc/pki/rpm-gpg/RPM-GPG-KEY-ATOMIA':
+        owner  => 'root',
+        group  => 'root',
+        mode   =>  '0644',
+        source => 'puppet:///modules/atomia/repository/RPM-GPG-KEY-ATOMIA',
+      }
+
+      file { '/etc/yum.repos.d/atomia-rhel7.repo':
+        owner   => 'root',
+        group   => 'root',
+        mode    =>  '0644',
+        source  => 'puppet:///modules/atomia/repository/atomia-rhel7.repo',
+        require => File['/etc/pki/rpm-gpg/RPM-GPG-KEY-ATOMIA'],
+      }
     }
     else
-    {   
-        exec { 'add rpm repo':
-            command => '/usr/bin/rpm -Uhv http://rpm.atomia.com/rhel6/atomia-repository-setup-1.0-1.el6.noarch.rpm',
-            unless => "/usr/bin/rpm -qi atomia-repository-setup-1.0-1.el6.noarch | /bin/grep  -c 'Build Date'"
-        }
+    {
+      exec { 'add rpm repo':
+        command => '/usr/bin/rpm -Uhv http://rpm.atomia.com/rhel6/atomia-repository-setup-1.0-1.el6.noarch.rpm',
+        unless  => "/usr/bin/rpm -qi atomia-repository-setup-1.0-1.el6.noarch | /bin/grep  -c 'Build Date'"
+      }
     }
-  }    
+  }
   else {
-    file { "/etc/apt/sources.list.d/atomia.list":
-        owner   => root,
-        group   => root,
-        mode    => "440",
-        content => "deb http://apt.atomia.com/${repo}",
+    file { '/etc/apt/sources.list.d/atomia.list':
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0440',
+      content => "deb http://apt.atomia.com/${repo}",
     }
 
-    file { "/etc/apt/ATOMIA-GPG-KEY.pub":
-        owner   => root,
-        group   => root,
-        mode    => "440",
-        source  => "puppet:///modules/atomia/repository/ATOMIA-GPG-KEY.pub"
+    file { '/etc/apt/ATOMIA-GPG-KEY.pub':
+      owner  => 'root',
+      group  => 'root',
+      mode   => '0440',
+      source => 'puppet:///modules/atomia/repository/ATOMIA-GPG-KEY.pub'
     }
 
-    exec { "add keys":
-        command => "/usr/bin/apt-key add /etc/apt/ATOMIA-GPG-KEY.pub",
-        onlyif => ["/usr/bin/test -f /etc/apt/ATOMIA-GPG-KEY.pub"],
-        subscribe => File["/etc/apt/ATOMIA-GPG-KEY.pub"],
-        refreshonly => true
+    exec { 'add keys':
+      command     => '/usr/bin/apt-key add /etc/apt/ATOMIA-GPG-KEY.pub',
+      onlyif      => ['/usr/bin/test -f /etc/apt/ATOMIA-GPG-KEY.pub'],
+      subscribe   => File['/etc/apt/ATOMIA-GPG-KEY.pub'],
+      refreshonly => true
     }
 
-    file { "/etc/apt/apt.conf.d/80atomiaupdate":
-        owner   => root,
-        group   => root,
-        mode    => "440",
-        source  => "puppet:///modules/atomia/repository/80atomiaupdate",
+    file { '/etc/apt/apt.conf.d/80atomiaupdate':
+      owner  => 'root',
+      group  => 'root',
+      mode   => '0440',
+      source => 'puppet:///modules/atomia/repository/80atomiaupdate',
     }
 
-    exec { "apt-update":
-        command => "/usr/bin/apt-get update",
-        require => File["/etc/apt/apt.conf.d/80atomiaupdate", "/etc/apt/ATOMIA-GPG-KEY.pub", "/etc/apt/sources.list.d/atomia.list"]
+    exec { 'apt-update':
+      command => '/usr/bin/apt-get update',
+      require => File['/etc/apt/apt.conf.d/80atomiaupdate', '/etc/apt/ATOMIA-GPG-KEY.pub', '/etc/apt/sources.list.d/atomia.list']
     }
 
-    Exec["apt-update"] -> Package <| |>
+    Exec['apt-update'] -> Package <| |>
   }
 
 }

--- a/manifests/awstats.pp
+++ b/manifests/awstats.pp
@@ -25,200 +25,199 @@
 ##### server_ip(advanced): .*
 
 class atomia::awstats (
-		$agent_user = "awstats",
-		$agent_password,
-		$ssl_enabled = false,
-		$content_share_nfs_location = '',
-		$configuration_share_nfs_location = '',
-		$ssl_cert_key = "",
-		$ssl_cert_file = "",
-		$skip_mount        = false,
-        $server_ip = $ipaddress
-	) {
+  $agent_user                       = 'awstats',
+  $agent_password,
+  $ssl_enabled                      = false,
+  $content_share_nfs_location       = '',
+  $configuration_share_nfs_location = '',
+  $ssl_cert_key                     = '',
+  $ssl_cert_file                    = '',
+  $skip_mount                       = false,
+  $server_ip                        = $ipaddress
+) {
 
-  package { atomia-pa-awstats: ensure => present }
-	package { atomiaprocesslogs: ensure => present }
+  package { 'atomia-pa-awstats': ensure => present }
+  package { 'atomiaprocesslogs': ensure => present }
 
-	package { awstats: ensure => installed }
-    package { procmail: ensure => installed }
-	
-	if !defined(Package['apache2-mpm-worker']) and !defined(Package['apache2-mpm-prefork']) and !defined(Package['apache2']) {
-		package { apache2-mpm-worker: ensure => installed }
-	}
-	
-	if $skip_mount == 'false' {
+  package { 'awstats': ensure => installed }
+  package { 'procmail': ensure => installed }
 
-		
-		$internal_zone = hiera('atomia::internaldns::zone_name','')
-		
-		if $content_share_nfs_location == '' {
-			package { 'glusterfs-client': ensure => present, }
-			
-			if !defined(File["/storage"]) {
-				file { "/storage":
-				ensure => directory,
-				}
-			}
-			
-			fstab::mount { '/storage/content':
-				ensure  => 'mounted',
-				device  => "gluster.${internal_zone}:/web_volume",
-				options => 'defaults,_netdev',
-				fstype  => 'glusterfs',
-				require => [Package['glusterfs-client'],File["/storage"]],
-			}	
-			fstab::mount { '/storage/configuration':
-				ensure  => 'mounted',
-				device  => "gluster.${internal_zone}:/config_volume",
-				options => 'defaults,_netdev',
-				fstype  => 'glusterfs',
-				require => [ Package['glusterfs-client'],File["/storage"]],
-			}			
-    	}
-		else
-		{
-			atomia::nfsmount { 'mount_content':
-				use_nfs3		 => 1,
-				mount_point  => '/storage/content',
-				nfs_location => $content_share_nfs_location
-			}
-	
-			atomia::nfsmount { 'mount_configuration':
-				use_nfs3		 => 1,
-				mount_point  => '/storage/configuration',
-				nfs_location => $configuration_share_nfs_location
-			}
-		}
-	}
-	if $ssl_enabled == 'true' {
-			$ssl_generate_var = "ssl"
+  if !defined(Package['apache2-mpm-worker']) and !defined(Package['apache2-mpm-prefork']) and !defined(Package['apache2']) {
+    package { 'apache2-mpm-worker': ensure => installed }
+  }
 
-			file { "/usr/local/awstats-agent/wildcard.key":
-					owner   => root,
-					group   => root,
-					mode    => "440",
-				  content => $ssl_cert_key,
-					require => Package["atomia-pa-awstats"]
-			}
-
-			file { "/usr/local/awstats-agent/wildcard.crt":
-					owner   => root,
-					group   => root,
-					mode    => "440",
-					content => $ssl_cert_file,
-					require => Package["atomia-pa-awstats"]
-			}
-	} else {
-			$ssl_generate_var = "nossl"
-	}
+  if $skip_mount == false {
 
 
-	file { "/usr/local/awstats-agent/settings.cfg":
-			owner   => root,
-			group   => root,
-			mode    => "440",
-			content => template("atomia/awstats/settings.cfg.erb"),
-			require => Package["atomia-pa-awstats"]
-	}
+    $internal_zone = hiera('atomia::internaldns::zone_name','')
 
-	service { awstats-agent:
-			name => awstats-agent,
-			enable => true,
-			ensure => running,
-			hasstatus => false,
-			pattern => "/etc/init.d/awstats-agent start",
-			subscribe => [ Package["atomia-pa-awstats"], File["/usr/local/awstats-agent/settings.cfg"] ],
-	}
+    if $content_share_nfs_location == '' {
+      package { 'glusterfs-client': ensure => present, }
 
-	file { "/etc/cron.d/awstats":
-		ensure => absent
-	}
-
-	file { "/etc/statisticsprocess.conf":
-			owner   => root,
-			group   => root,
-			mode    => "400",
-			source  => "puppet:///modules/atomia/awstats/statisticsprocess.conf",
-	}
-
-	file { "/etc/cron.d/convertlogs":
-			owner   => root,
-			group   => root,
-			mode    => "444",
-			source  => "puppet:///modules/atomia/awstats/convertlogs",
-	}
-	
-	file { "/storage/content/logs/iis_logs/convert_logs.sh":
-			owner   => root,
-			group   => root,
-			mode    => "544",
-			source  => "puppet:///modules/atomia/awstats/convert_logs.sh",
-	}
-
-	file { "/etc/apache2/conf-enabled/awstats.conf":
-			owner   => root,
-			group   => root,
-			mode    => "444",
-			source  => "puppet:///modules/atomia/awstats/awstats.conf",
-			notify	=> Service["apache2"],
-			require => [Package['awstats'],Package['atomia-pa-awstats']],
-	}
-	
-	file { "/etc/awstats/awstats.conf.local":
-			owner   => root,
-			group   => root,
-			mode    => "444",
-			source  => "puppet:///modules/atomia/awstats/awstats.conf.local",
-			require => Package['awstats'],
-	}
-	
-	file { "/storage/content/systemservices/public_html/nostats.html":
-			owner   => root,
-			group   => root,
-			mode    => "444",
-			source  => "puppet:///modules/atomia/awstats/nostats.html",
-	}
-
-	if !defined(File['/etc/apache2/sites-available/default']) {
-	        file { "/etc/apache2/sites-available/default":
-			ensure	=> absent,
-		}
-	}
-
-	if !defined(File['/etc/apache2/sites-enabled/000-default']) {
-	        file { "/etc/apache2/sites-enabled/000-default":
-			ensure	=> absent,
-		}
-	}
-
-	if !defined(Service['apache2']) {
-	        service { apache2:
-			name => apache2,
-			enable => true,
-	                ensure => running,
-		}
-	}
-
-	if !defined(Exec['force-reload-apache']) {
-	        exec { "force-reload-apache":
-			refreshonly => true,
-			before => Service["apache2"],
-			command => "/etc/init.d/apache2 force-reload",
-		}
-	}
-
-	if !defined(Exec['/usr/sbin/a2enmod rewrite']) {
-	        exec { "/usr/sbin/a2enmod rewrite":
-			unless => "/usr/bin/test -f /etc/apache2/mods-enabled/rewrite.load",
-			require => Package["apache2-mpm-worker"],
-			notify => Exec["force-reload-apache"],
-		}
+      if !defined(File['/storage']) {
+        file { '/storage':
+          ensure => directory,
         }
+      }
 
-    file { '/etc/cron.d/rotate-awstats-logs':
-        ensure  => present,
-        content => "0 0 * * * root lockfile -r0 /var/run/rotate-awstats && (find /var/log/awstats/ -mtime +14 -exec rm -f '{}' '+'; rm -f /var/run/rotate-awstats.lock)"
+      fstab::mount { '/storage/content':
+        ensure  => 'mounted',
+        device  => "gluster.${internal_zone}:/web_volume",
+        options => 'defaults,_netdev',
+        fstype  => 'glusterfs',
+        require => [Package['glusterfs-client'],File['/storage']],
+      }
+      fstab::mount { '/storage/configuration':
+        ensure  => 'mounted',
+        device  => "gluster.${internal_zone}:/config_volume",
+        options => 'defaults,_netdev',
+        fstype  => 'glusterfs',
+        require => [ Package['glusterfs-client'],File['/storage']],
+      }
     }
+    else
+    {
+      atomia::nfsmount { 'mount_content':
+        use_nfs3     => 1,
+        mount_point  => '/storage/content',
+        nfs_location => $content_share_nfs_location
+      }
+
+      atomia::nfsmount { 'mount_configuration':
+        use_nfs3     => 1,
+        mount_point  => '/storage/configuration',
+        nfs_location => $configuration_share_nfs_location
+      }
+    }
+  }
+  if $ssl_enabled == true {
+    $ssl_generate_var = 'ssl'
+
+    file { '/usr/local/awstats-agent/wildcard.key':
+      owner   => root,
+      group   => root,
+      mode    => '0440',
+      content => $ssl_cert_key,
+      require => Package['atomia-pa-awstats']
+    }
+
+    file { '/usr/local/awstats-agent/wildcard.crt':
+      owner   => root,
+      group   => root,
+      mode    => '0440',
+      content => $ssl_cert_file,
+      require => Package['atomia-pa-awstats']
+    }
+  } else {
+    $ssl_generate_var = 'nossl'
+  }
+
+
+  file { '/usr/local/awstats-agent/settings.cfg':
+    owner   => root,
+    group   => root,
+    mode    => '0440',
+    content => template('atomia/awstats/settings.cfg.erb'),
+    require => Package['atomia-pa-awstats']
+  }
+
+  service { 'awstats-agent':
+    ensure    => running,
+    name      => awstats-agent,
+    enable    => true,
+    hasstatus => false,
+    pattern   => '/etc/init.d/awstats-agent start',
+    subscribe => [ Package['atomia-pa-awstats'], File['/usr/local/awstats-agent/settings.cfg'] ],
+  }
+
+  file { '/etc/cron.d/awstats':
+    ensure => absent
+  }
+
+  file { '/etc/statisticsprocess.conf':
+    owner  => root,
+    group  => root,
+    mode   => '0400',
+    source => 'puppet:///modules/atomia/awstats/statisticsprocess.conf',
+  }
+
+  file { '/etc/cron.d/convertlogs':
+    owner  => root,
+    group  => root,
+    mode   => '0444',
+    source => 'puppet:///modules/atomia/awstats/convertlogs',
+  }
+
+  file { '/storage/content/logs/iis_logs/convert_logs.sh':
+    owner  => root,
+    group  => root,
+    mode   => '0544',
+    source => 'puppet:///modules/atomia/awstats/convert_logs.sh',
+  }
+
+  file { '/etc/apache2/conf-enabled/awstats.conf':
+    owner   => root,
+    group   => root,
+    mode    => '0444',
+    source  => 'puppet:///modules/atomia/awstats/awstats.conf',
+    notify  => Service['apache2'],
+    require => [Package['awstats'],Package['atomia-pa-awstats']],
+  }
+
+  file { '/etc/awstats/awstats.conf.local':
+    owner   => root,
+    group   => root,
+    mode    => '0444',
+    source  => 'puppet:///modules/atomia/awstats/awstats.conf.local',
+    require => Package['awstats'],
+  }
+
+  file { '/storage/content/systemservices/public_html/nostats.html':
+    owner  => root,
+    group  => root,
+    mode   => '0444',
+    source => 'puppet:///modules/atomia/awstats/nostats.html',
+  }
+
+  if !defined(File['/etc/apache2/sites-available/default']) {
+    file { '/etc/apache2/sites-available/default':
+      ensure  => absent,
+    }
+  }
+
+  if !defined(File['/etc/apache2/sites-enabled/000-default']) {
+    file { '/etc/apache2/sites-enabled/000-default':
+      ensure  => absent,
+    }
+  }
+
+  if !defined(Service['apache2']) {
+    service { 'apache2':
+      ensure => running,
+      enable => true,
+    }
+  }
+
+  if !defined(Exec['force-reload-apache']) {
+    exec { 'force-reload-apache':
+      refreshonly => true,
+      before      => Service['apache2'],
+      command     => '/etc/init.d/apache2 force-reload',
+    }
+  }
+
+  if !defined(Exec['/usr/sbin/a2enmod rewrite']) {
+    exec { '/usr/sbin/a2enmod rewrite':
+      unless  => '/usr/bin/test -f /etc/apache2/mods-enabled/rewrite.load',
+      require => Package['apache2-mpm-worker'],
+      notify  => Exec['force-reload-apache'],
+    }
+  }
+
+  file { '/etc/cron.d/rotate-awstats-logs':
+    ensure  => present,
+    content => "0 0 * * * root lockfile -r0 /var/run/rotate-awstats && (find /var/log/awstats/ -mtime +14 -exec rm -f '{}' '+'; rm -f /var/run/rotate-awstats.lock)"
+  }
 
 }
 

--- a/manifests/bootstrap.pp
+++ b/manifests/bootstrap.pp
@@ -1,19 +1,19 @@
 class atomia::bootstrap
 {
-  if $kernel == "Linux" {
-    case $osfamily {
+  if $::kernel == 'Linux' {
+    case $::osfamily {
       'RedHat' : { $facter_path = '/usr/share/ruby/vendor_ruby/facter' }
       default  : { $facter_path = '/usr/lib/ruby/vendor_ruby/facter' }
     }
-     file { "${facter_path}/atomia_role.rb":
-       owner  => root,
-       group  => root,
-       mode   => "755",
-       source => "puppet:///modules/atomia/atomia_role.rb"
-     }
+    file { "${facter_path}/atomia_role.rb":
+      owner  => 'root',
+      group  => 'root',
+      mode   => '0755',
+      source => 'puppet:///modules/atomia/atomia_role.rb'
+    }
   }
-  if $kernel == "windows" {
-    file { "C:\ProgramData\PuppetLabs\facter\facts.d\atomia_role.ps1":
+  if $::kernel == 'windows' {
+    file { 'C:\ProgramData\PuppetLabs\facter\facts.d\atomia_role.ps1':
       content => template('atomia/active_directory/atomia_role.ps1.erb'),
     }
   }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -15,10 +15,10 @@
 ##### puppet_ip: $puppet_ip
 
 class atomia::config (
-	$atomia_domain	  			= "",
-	$atomia_admin_password   		= "Administrator",
-	$puppet_hostname			= "$puppet_host",
-	$puppet_ip				= "$puppet_ip",
+  $atomia_domain         = '',
+  $atomia_admin_password = 'Administrator',
+  $puppet_hostname       = $puppet_host,
+  $puppet_ip             = $puppet_ip,
 ){
 
 }

--- a/manifests/cronagent.pp
+++ b/manifests/cronagent.pp
@@ -27,47 +27,46 @@
 ##### mail_ssl(advanced): [0-1]
 
 class atomia::cronagent (
-	$global_auth_token, 
-	$min_part = 0,  
-	$max_part = 1000, 
-	$mail_host = "localhost", 
-	$mail_port = 25, 
-	$mail_ssl = 0, 
-	$mail_from = "", 
-	$mail_user = "", 
-	$mail_pass = "",
-	$base_url  = "http://$fqdn:10101"
+  $global_auth_token,
+  $min_part           = 0,
+  $max_part           = 1000,
+  $mail_host          = 'localhost',
+  $mail_port          = 25,
+  $mail_ssl           = 0,
+  $mail_from          = '',
+  $mail_user          = '',
+  $mail_pass          = '',
+  $base_url           = "http://${::fqdn}:10101"
 ){
-	
-	include atomia::mongodb
-	
-	package { "atomia-cronagent": 
-		ensure => present,
-		require => Package["mongodb-10gen"]
-	}
 
-	if $mail_host == "localhost" or $mail_host == "127.0.0.1" {
-		package { "postfix" :
-			ensure => present,
-		}
-	}
+  include atomia::mongodb
+
+  package { 'atomia-cronagent':
+    ensure  => present,
+    require => Package['mongodb-10gen']
+  }
+
+  if $mail_host == 'localhost' or $mail_host == '127.0.0.1' {
+    package { 'postfix' :
+      ensure => present,
+    }
+  }
 
 
-	file { "/etc/default/cronagent":
-		owner   => root,
-		group   => root,
-		mode    => "440",
-		content => template("atomia/cronagent/settings.cfg.erb"),
-		require => Package["atomia-cronagent"],		
-	}
-	
-	service { "atomia-cronagent":
-			name => atomia-cronagent,
-			enable => true,
-			ensure => running,
-			hasstatus => false,
-			pattern => "/usr/bin/(atomia-)?cronagent",
-			require => [ Package["atomia-cronagent"], File["/etc/default/cronagent"] ],
-			subscribe => File["/etc/default/cronagent"],
-	}
+  file { '/etc/default/cronagent':
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0440',
+    content => template('atomia/cronagent/settings.cfg.erb'),
+    require => Package['atomia-cronagent'],
+  }
+
+  service { 'atomia-cronagent':
+    ensure    => running,
+    enable    => true,
+    hasstatus => false,
+    pattern   => '/usr/bin/(atomia-)?cronagent',
+    require   => [ Package['atomia-cronagent'], File['/etc/default/cronagent'] ],
+    subscribe => File['/etc/default/cronagent'],
+  }
 }

--- a/manifests/daggre.pp
+++ b/manifests/daggre.pp
@@ -17,122 +17,122 @@
 ##### use_nfs3(advanced): %boolean
 
 class atomia::daggre (
-	$global_auth_token,
-	$content_share_nfs_location	= '',
-	$config_share_nfs_location	= '',
-	$use_nfs3			= true,
-	$ip_addr			= $ipaddress
+  $global_auth_token,
+  $content_share_nfs_location = '',
+  $config_share_nfs_location  = '',
+  $use_nfs3                   = true,
+  $ip_addr                    = $ipaddress,
 ) {
-	
-	include atomia::mongodb
 
-	class { 'apt': }
-	
-	if $operatingsystem == "Ubuntu" {
-		apt::source { 'nodesource_0.12':
-			location	=> 'https://deb.nodesource.com/node_0.12',
-			release		=> $codename,
-			repos		=> 'main',
-			key		=> {
-				id	=> "9FD3B784BC1C6FC31A8A0A1C1655A0AB68576280",
-				source	=> 'https://deb.nodesource.com/gpgkey/nodesource.gpg.key'
-  			},
-			include		=> {
-				'src' => true,
-				'deb' => true,
-			},
-		}
+  include atomia::mongodb
 
-		package { nodejs:
-			ensure	=> latest,
-			require => [ Apt::Source['nodesource_0.12'] ]
-		}
-	} else {
-		package { nodejs: ensure => present, }
-	}
+  class { 'apt': }
 
-	package { python-software-properties:
-		ensure => present,
-	}  
- 
-	package { "daggre":
-		ensure	=> present,
-		require => [Package["mongodb-10gen"], Package["nodejs"]],
-	}
+  if $::operatingsystem == 'Ubuntu' {
+    apt::source { 'nodesource_0.12':
+      location => 'https://deb.nodesource.com/node_0.12',
+      release  => $::codename,
+      repos    => 'main',
+      key      => {
+        id     => '9FD3B784BC1C6FC31A8A0A1C1655A0AB68576280',
+        source => 'https://deb.nodesource.com/gpgkey/nodesource.gpg.key'
+      },
+      include  => {
+        'src' => true,
+        'deb' => true,
+      },
+    }
 
-	package { "atomia-daggre-reporters-disk":
-		ensure	=> present,
-		require => Package["daggre"]
-	}
+    package { 'nodejs':
+      ensure  => latest,
+      require => [ Apt::Source['nodesource_0.12'] ]
+    }
+  } else {
+    package { 'nodejs': ensure => present, }
+  }
 
-	package { "atomia-daggre-reporters-weblog":
-		ensure	=> present,
-		require => Package["daggre"]
-	}
+  package { 'python-software-properties':
+    ensure => present,
+  }
 
-	file { "/etc/default/daggre":
-		owner		=> root,
-		group		=> root,
-		mode		=> "440",
-		content		=> template("atomia/daggre/settings.cfg.erb"),
-		require		=> Package["daggre"],
-	}
+  package { 'daggre':
+    ensure  => present,
+    require => [Package['mongodb-10gen'], Package['nodejs']],
+  }
 
-	file { "/etc/daggre_submit.conf":
-		owner		=> root,
-		group		=> root,
-		mode		=> "440",
-		content 	=> template("atomia/daggre/daggre_submit.conf.erb"),
-		require 	=> Package["atomia-daggre-reporters-disk", "atomia-daggre-reporters-weblog"],
-	}
+  package { 'atomia-daggre-reporters-disk':
+    ensure  => present,
+    require => Package['daggre']
+  }
 
-	service { "daggre":
-		name		=> daggre,
-		enable		=> true,
-		ensure		=> running,
-		pattern		=> ".*/usr/bin/daggre.*",
-		require		=> [Package["daggre"], File["/etc/default/daggre"]],
-		subscribe	=> File["/etc/default/daggre"],
-	}
+  package { 'atomia-daggre-reporters-weblog':
+    ensure  => present,
+    require => Package['daggre']
+  }
 
-		$internal_zone = hiera('atomia::internaldns::zone_name','')
-		
-		if $content_share_nfs_location == '' {
-			package { 'glusterfs-client': ensure => present, }
-			
-			if !defined(File["/storage"]) {
-				file { "/storage":
-				ensure => directory,
-				}
-			}
-			
-			fstab::mount { '/storage/content':
-				ensure  => 'mounted',
-				device  => "gluster.${internal_zone}:/web_volume",
-				options => 'defaults,_netdev',
-				fstype  => 'glusterfs',
-				require => [Package['glusterfs-client'],File["/storage"]],
-			}	
-			fstab::mount { '/storage/configuration':
-				ensure  => 'mounted',
-				device  => "gluster.${internal_zone}:/config_volume",
-				options => 'defaults,_netdev',
-				fstype  => 'glusterfs',
-				require => [ Package['glusterfs-client'],File["/storage"]],
-			}			
-    	}
-		else
-		{
-			atomia::nfsmount { 'mount_content':
-				use_nfs3		 => 1,
-				mount_point  => '/storage/content',
-				nfs_location => $content_share_nfs_location
-			}
-	
-			atomia::nfsmount { 'mount_configuration':
-				use_nfs3		 => 1,
-				mount_point  => '/storage/configuration',
-				nfs_location => $config_share_nfs_location
-			}
-		}
+  file { '/etc/default/daggre':
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0440',
+    content => template('atomia/daggre/settings.cfg.erb'),
+    require => Package['daggre'],
+  }
+
+  file { '/etc/daggre_submit.conf':
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0440',
+    content => template('atomia/daggre/daggre_submit.conf.erb'),
+    require => Package['atomia-daggre-reporters-disk', 'atomia-daggre-reporters-weblog'],
+  }
+
+  service { 'daggre':
+    ensure    => running,
+    name      => 'daggre',
+    enable    => true,
+    pattern   => '.*/usr/bin/daggre.*',
+    require   => [Package['daggre'], File['/etc/default/daggre']],
+    subscribe => File['/etc/default/daggre'],
+  }
+
+  $internal_zone = hiera('atomia::internaldns::zone_name','')
+
+  if $content_share_nfs_location == '' {
+    package { 'glusterfs-client': ensure => present, }
+
+    if !defined(File['/storage']) {
+      file { '/storage':
+        ensure => directory,
+      }
+    }
+
+    fstab::mount { '/storage/content':
+      ensure  => 'mounted',
+      device  => "gluster.${internal_zone}:/web_volume",
+      options => 'defaults,_netdev',
+      fstype  => 'glusterfs',
+      require => [Package['glusterfs-client'],File['/storage']],
+    }
+    fstab::mount { '/storage/configuration':
+      ensure  => 'mounted',
+      device  => "gluster.${internal_zone}:/config_volume",
+      options => 'defaults,_netdev',
+      fstype  => 'glusterfs',
+      require => [ Package['glusterfs-client'],File['/storage']],
+    }
+  }
+  else
+  {
+    atomia::nfsmount { 'mount_content':
+      use_nfs3     => 1,
+      mount_point  => '/storage/content',
+      nfs_location => $content_share_nfs_location
+    }
+
+    atomia::nfsmount { 'mount_configuration':
+      use_nfs3     => 1,
+      mount_point  => '/storage/configuration',
+      nfs_location => $config_share_nfs_location
+    }
+  }
 }

--- a/manifests/domainreg.pp
+++ b/manifests/domainreg.pp
@@ -23,69 +23,67 @@
 ##### domainreg_tld_config_hash: %domainreg_tld_config_hash
 
 class atomia::domainreg (
-	$service_url	  		= "http://$fqdn/domainreg",
-	$service_username     		= "domainreg",
-	$service_password     		= "",
-	$db_hostname			= "127.0.0.1",
-	$db_username			= "domainreg",
-	$db_password			= "",
-	$domainreg_global_config	= "",
-	$domainreg_tld_config_hash	= {}
+  $service_url               = "http://${::fqdn}/domainreg",
+  $service_username          = 'domainreg',
+  $service_password          = '',
+  $db_hostname               = '127.0.0.1',
+  $db_username               = 'domainreg',
+  $db_password               = '',
+  $domainreg_global_config   = '',
+  $domainreg_tld_config_hash = {}
 ){
 
-	# Support both hash and Json format for domainreg_tld_config_hash
-	if(!is_hash($domainreg_tld_config_hash)) {
-		$config_hash = parsejson($domainreg_tld_config_hash)
-	}
-	else {
-		$config_hash = $domainreg_tld_config_hash
-	}
-	$domainreg_global_config_default = file("atomia/domainreg/domainreg_global_default.conf")
+  # Support both hash and Json format for domainreg_tld_config_hash
+  if(!is_hash($domainreg_tld_config_hash)) {
+    $config_hash = parsejson($domainreg_tld_config_hash)
+  }
+  else {
+    $config_hash = $domainreg_tld_config_hash
+  }
+  $domainreg_global_config_default = file('atomia/domainreg/domainreg_global_default.conf')
 
-	package { atomiadomainregistration-masterserver:
-		ensure => present,
-		require => [ File["/etc/domainreg.conf"] ]
-	}
+  package { 'atomiadomainregistration-masterserver':
+    ensure  => present,
+    require => [ File['/etc/domainreg.conf'] ]
+  }
 
-	package { atomiadomainregistration-client: ensure => present }
+  package { 'atomiadomainregistration-client': ensure => present }
 
-	package { procmail: ensure => present }
+  package { 'procmail': ensure => present }
 
 
-	file { "/etc/domainreg.conf":
-		path    => "/etc/domainreg.conf",
-		owner   => root,
-		group   => root,
-		mode    => "444",
-		content => template('atomia/domainreg/domainreg.conf'),
-		notify => [ Service["atomiadomainregistration-api"], Service["apache2"] ]
-	}
+  file { '/etc/domainreg.conf':
+    path    => '/etc/domainreg.conf',
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0444',
+    content => template('atomia/domainreg/domainreg.conf'),
+    notify  => [ Service['atomiadomainregistration-api'], Service['apache2'] ]
+  }
 
-	service { atomiadomainregistration-api:
-		name => atomiadomainregistration-api,
-		enable => true,
-		ensure => running,
-		pattern => ".*/usr/bin/domainregistration.*",
-		require => [ Package["atomiadomainregistration-masterserver"], Package["atomiadomainregistration-client"], File["/etc/domainreg.conf"] ],
-	}
+  service { 'atomiadomainregistration-api':
+    ensure  => running,
+    enable  => true,
+    pattern => '.*/usr/bin/domainregistration.*',
+    require => [ Package['atomiadomainregistration-masterserver'], Package['atomiadomainregistration-client'], File['/etc/domainreg.conf'] ],
+  }
 
-	if !defined(Class['atomia::apache_password_protect']) {
-		class { 'atomia::apache_password_protect':
-			username => $service_username,
-			password => $service_password,
-            require => Package['atomiadomainregistration-masterserver'],
-		}
-	}
-
-	service { apache2:
-		name => apache2,
-		enable => true,
-		ensure => running,
-		require => Package['atomiadomainregistration-masterserver'],
-	}
-
-	file { '/etc/cron.d/rotate-domainreg-logs':
-		ensure  => present,
-		content => "0 0 * * * root lockfile -r0 /var/run/rotate-domainreg-logs && (find /var/log/atomiadomainregistration -mtime +14 -exec rm -f '{}' '+'; rm -f /var/run/rotate-domainreg-logs.lock)",
+  if !defined(Class['atomia::apache_password_protect']) {
+    class { 'atomia::apache_password_protect':
+      username => $service_username,
+      password => $service_password,
+      require  => Package['atomiadomainregistration-masterserver'],
     }
+  }
+
+  service { 'apache2':
+    ensure  => running,
+    enable  => true,
+    require => Package['atomiadomainregistration-masterserver'],
+  }
+
+  file { '/etc/cron.d/rotate-domainreg-logs':
+    ensure  => present,
+    content => "0 0 * * * root lockfile -r0 /var/run/rotate-domainreg-logs && (find /var/log/atomiadomainregistration -mtime +14 -exec rm -f '{}' '+'; rm -f /var/run/rotate-domainreg-logs.lock)",
+  }
 }

--- a/manifests/glusterfs.pp
+++ b/manifests/glusterfs.pp
@@ -19,99 +19,100 @@
 
 
 class atomia::glusterfs (
-	$web_content_volume_size		= "100G",
-	$configuration_volume_size		= "10G",
-	$mail_volume_size				= "100G",
-	$peers							= "$fqdn",
-	$physical_volume				= "/dev/sdb",
+  $web_content_volume_size   = '100G',
+  $configuration_volume_size = '10G',
+  $mail_volume_size          = '100G',
+  $peers                     = $fqdn,
+  $physical_volume           = '/dev/sdb',
 ) {
-	
-	$is_first_node = hiera('atomia::glusterfs::is_first_node', false)
 
-	# Set ip correctly when on ec2
-	if $ec2_public_ipv4 {
-		$public_ip = $ec2_public_ipv4
-	} else {
-		$public_ip = $ipaddress_eth0
-	}
+  $is_first_node = hiera('atomia::glusterfs::is_first_node', false)
 
-	$netbios_domain_name = hiera('atomia::active_directory::netbios_domain_name')
-	$domain_name = hiera('atomia::active_directory::domain_name')
-	$zone_name = hiera('atomia::internaldns::zone_name')
-	$ad_password = hiera('atomia::active_directory::windows_admin_password')
-	$internal_zone = hiera('atomia::internaldns::zone_name')
-	host { 'domain-member-host':
-		name		=> "${::hostname}.$domain_name",
-		ip	=> "${::ipaddress_eth0}"
-	}
+  # Set ip correctly when on ec2
+  if $::ec2_public_ipv4 {
+    $public_ip = $::ec2_public_ipv4
+  } else {
+    $public_ip = $::ipaddress_eth0
+  }
 
-	@@bind::a { "${fqdn}-gluster-dns":
-	  ensure    => 'present',
-	  zone      => $internal_zone,
-	  ptr       => false,
-	  hash_data => {
-	    'gluster' => { owner => $ipaddress },
-	  },
-	}
+  $netbios_domain_name = hiera('atomia::active_directory::netbios_domain_name')
+  $domain_name         = hiera('atomia::active_directory::domain_name')
+  $zone_name           = hiera('atomia::internaldns::zone_name')
+  $ad_password         = hiera('atomia::active_directory::windows_admin_password')
+  $internal_zone       = hiera('atomia::internaldns::zone_name')
+  host { 'domain-member-host':
+    name => "${::hostname}.${domain_name}",
+    ip   => $::ipaddress_eth0
+  }
 
-
-	$peers_arr = split($peers,',')
-	$peers_size = size($peers_arr)
-
-	package { 'python-software-properties': ensure => present }
-	package { 'xfsprogs': ensure => present }
-	package { 'lvm2': ensure => present }
-	package { 'samba': ensure => present }
-	package { 'ctdb': ensure => present}
-
-	class { 'glusterfs::server':
-  	peers => $peers_arr,
-	}
-
-	file { [ '/export', '/export/web', '/export/mail', '/export/config' ]:
-  	seltype => 'usr_t',
-  	ensure  => directory,
-	}
-
-	exec { "create-physical-volume":
-		command => "/sbin/pvcreate ${physical_volume}",
-		unless 	=> "/sbin/pvdisplay | /bin/grep ${physical_volume} >/dev/null 2>&1",
-		require	=> Package['lvm2']
-	}
-
-  exec { "create-volume-group":
-    command => "/sbin/vgcreate gluster ${physical_volume}",
-    unless  => "/sbin/vgs | /bin/grep gluster  >/dev/null 2>&1",
-    require => Exec["create-physical-volume"]
+  @@bind::a { "${fqdn}-gluster-dns":
+    ensure    => 'present',
+    zone      => $internal_zone,
+    ptr       => false,
+    hash_data => {
+      'gluster' => {
+        owner => $::ipaddress },
+    },
   }
 
 
-	exec { 'create-web-lv':
-  	command => "/sbin/lvcreate -L ${web_content_volume_size} -n web gluster",
-		creates => '/dev/gluster/web',
-  	notify  => Exec['mkfs web'],
-		require	=> Exec["create-volume-group"]
-	}
+  $peers_arr = split($peers,',')
+  $peers_size = size($peers_arr)
 
-	exec { 'mkfs web':
-  	command     => '/sbin/mkfs.xfs -i size=512 /dev/gluster/web',
-  	require     => [ Package['xfsprogs'], Exec['create-web-lv'] ],
-  	refreshonly => true,
-	}
+  package { 'python-software-properties': ensure => present }
+  package { 'xfsprogs': ensure => present }
+  package { 'lvm2': ensure => present }
+  package { 'samba': ensure => present }
+  package { 'ctdb': ensure => present}
 
-	mount { '/export/web':
-  	device  => '/dev/gluster/web',
-  	fstype  => 'xfs',
-  	options => 'defaults',
-  	ensure  => mounted,
-  	require => [ Exec['mkfs web'], File['/export/web'] ],
-	}
+  class { 'glusterfs::server':
+    peers => $peers_arr,
+  }
+
+  file { [ '/export', '/export/web', '/export/mail', '/export/config' ]:
+    ensure  => directory,
+    seltype => 'usr_t',
+  }
+
+  exec { 'create-physical-volume':
+    command => "/sbin/pvcreate ${physical_volume}",
+    unless  => "/sbin/pvdisplay | /bin/grep ${physical_volume} >/dev/null 2>&1",
+    require => Package['lvm2']
+  }
+
+  exec { 'create-volume-group':
+    command => "/sbin/vgcreate gluster ${physical_volume}",
+    unless  => '/sbin/vgs | /bin/grep gluster  >/dev/null 2>&1',
+    require => Exec['create-physical-volume']
+  }
+
+
+  exec { 'create-web-lv':
+    command => "/sbin/lvcreate -L ${web_content_volume_size} -n web gluster",
+    creates => '/dev/gluster/web',
+    notify  => Exec['mkfs web'],
+    require => Exec['create-volume-group']
+  }
+
+  exec { 'mkfs web':
+    command     => '/sbin/mkfs.xfs -i size=512 /dev/gluster/web',
+    require     => [ Package['xfsprogs'], Exec['create-web-lv'] ],
+    refreshonly => true,
+  }
+
+  mount { '/export/web':
+    ensure  => mounted,
+    device  => '/dev/gluster/web',
+    fstype  => 'xfs',
+    options => 'defaults',
+    require => [ Exec['mkfs web'], File['/export/web'] ],
+  }
 
   exec { 'create-mail-lv':
     command => "/sbin/lvcreate -L ${mail_volume_size} -n mail gluster",
     creates => '/dev/gluster/mail',
     notify  => Exec['mkfs mail'],
-    require => Exec["create-volume-group"]
+    require => Exec['create-volume-group']
   }
 
   exec { 'mkfs mail':
@@ -121,10 +122,10 @@ class atomia::glusterfs (
   }
 
   mount { '/export/mail':
+    ensure  => mounted,
     device  => '/dev/gluster/mail',
     fstype  => 'xfs',
     options => 'defaults',
-    ensure  => mounted,
     require => [ Exec['mkfs mail'], File['/export/mail'] ],
   }
 
@@ -132,7 +133,7 @@ class atomia::glusterfs (
     command => "/sbin/lvcreate -L ${configuration_volume_size} -n config gluster",
     creates => '/dev/gluster/config',
     notify  => Exec['mkfs config'],
-    require => Exec["create-volume-group"]
+    require => Exec['create-volume-group']
   }
 
   exec { 'mkfs config':
@@ -142,125 +143,125 @@ class atomia::glusterfs (
   }
 
   mount { '/export/config':
+    ensure  => mounted,
     device  => '/dev/gluster/config',
     fstype  => 'xfs',
     options => 'defaults',
-    ensure  => mounted,
     require => [ Exec['mkfs config'], File['/export/config'] ],
   }
 
 
-	# Create Gluster volumes
-	file { '/export/web/vol1':
-		ensure => directory,
-		require => Mount["/export/web"]
-	}
-
-	file { '/export/mail/vol1':
-		ensure => directory,
-		require => Mount["/export/mail"]
-	}
-
-	file { '/export/config/vol1':
-		ensure => directory,
-		require => Mount["/export/config"]
-	}
-
-	class { 'fstab' : }
-	
-	file { '/storage':
-		ensure	=> directory,
-	}
-	
-	if($peers_size > 1)
-	{
-		if($is_first_node) {
-			exec { "gluster volume create /export/web":
-				command => template('atomia/glusterfs/create_web_volume.erb'),
-				creates => "/var/lib/glusterd/vols/web_volume",
-				require => [ Class['glusterfs::server'], File['/export/web/vol1'] ],
-				unless	=> "/usr/bin/test `/usr/sbin/gluster peer status | /bin/grep -c Hostname` -eq ${peers_size};",
-				notify	=> Exec['start web volume'],
-			}
-		}
-		
-		fstab::mount { '/storage/content':
-			ensure  => 'mounted',
-			device  => "gluster.${internal_zone}:/web_volume",
-			options => 'defaults,_netdev',
-			fstype  => 'glusterfs',
-			require => [Exec['start web volume'], File['/storage']],
-		}		
-
-		exec { 'start web volume':
-			command => '/usr/sbin/gluster volume start web_volume',
-			refreshonly	=> true
-		}
+  # Create Gluster volumes
+  file { '/export/web/vol1':
+    ensure  => directory,
+    require => Mount['/export/web']
   }
 
-	
-	if($peers_size > 1)
-	{
-		if($is_first_node) {
-			exec { "gluster volume create /export/mail":
-				command => template('atomia/glusterfs/create_mail_volume.erb'),
-				creates => "/var/lib/glusterd/vols/mail_volume",
-				require => [ Class['glusterfs::server'], File['/export/mail/vol1'] ],
-				unless	=> "/usr/bin/test `/usr/sbin/gluster peer status | /bin/grep -c Hostname` -eq ${peers_size};",
-				notify	=> Exec['start mail volume'],
-			}
-		}
-	}
+  file { '/export/mail/vol1':
+    ensure  => directory,
+    require => Mount['/export/mail']
+  }
 
-	exec { 'start mail volume':
-		command => '/usr/sbin/gluster volume start mail_volume',
-		refreshonly	=> true
-	}
+  file { '/export/config/vol1':
+    ensure  => directory,
+    require => Mount['/export/config']
+  }
 
-	if($peers_size > 1)
-	{
-		if($is_first_node) {
-			exec { "gluster volume create /export/config":
-				command => template('atomia/glusterfs/create_config_volume.erb'),
-				creates => "/var/lib/glusterd/vols/config_volume",
-				require => [ Class['glusterfs::server'], File['/export/config/vol1'] ],
-				unless	=> "/usr/bin/test `/usr/sbin/gluster peer status | /bin/grep -c Hostname` -eq ${peers_size};",
-				notify	=> Exec['start config volume'],
-			}
-		}
+  class { 'fstab' : }
 
-		exec { 'start config volume':
-			command => '/usr/sbin/gluster volume start config_volume',
-			refreshonly	=> true
-		}	
-			
-		fstab::mount { '/storage/configuration':
-			ensure  => 'mounted',
-			device  => "gluster.${internal_zone}:/config_volume",
-			options => 'defaults,_netdev',
-			fstype  => 'glusterfs',
-			require => [Exec['start config volume'], File['/storage']],
-		}		
-	}
+  file { '/storage':
+    ensure  => directory,
+  }
+
+  if($peers_size > 1)
+  {
+    if($is_first_node) {
+      exec { 'gluster volume create /export/web':
+        command => template('atomia/glusterfs/create_web_volume.erb'),
+        creates => '/var/lib/glusterd/vols/web_volume',
+        require => [ Class['glusterfs::server'], File['/export/web/vol1'] ],
+        unless  => "/usr/bin/test `/usr/sbin/gluster peer status | /bin/grep -c Hostname` -eq ${peers_size};",
+        notify  => Exec['start web volume'],
+      }
+    }
+
+    fstab::mount { '/storage/content':
+      ensure  => 'mounted',
+      device  => "gluster.${internal_zone}:/web_volume",
+      options => 'defaults,_netdev',
+      fstype  => 'glusterfs',
+      require => [Exec['start web volume'], File['/storage']],
+    }
+
+    exec { 'start web volume':
+      command     => '/usr/sbin/gluster volume start web_volume',
+      refreshonly => true
+    }
+  }
 
 
+  if($peers_size > 1)
+  {
+    if($is_first_node) {
+      exec { 'gluster volume create /export/mail':
+        command => template('atomia/glusterfs/create_mail_volume.erb'),
+        creates => '/var/lib/glusterd/vols/mail_volume',
+        require => [ Class['glusterfs::server'], File['/export/mail/vol1'] ],
+        unless  => "/usr/bin/test `/usr/sbin/gluster peer status | /bin/grep -c Hostname` -eq ${peers_size};",
+        notify  => Exec['start mail volume'],
+      }
+    }
+  }
 
-	# Configure Samba
-	file { '/etc/samba/smb.conf':
-		content => template('atomia/glusterfs/smb.conf.erb'),
-		require	=> Package['samba']
-	}
+  exec { 'start mail volume':
+    command     => '/usr/sbin/gluster volume start mail_volume',
+    refreshonly => true
+  }
 
-	file { '/etc/samba/smbusers':
-		ensure	=> present,
-		content => "root = ${$netbios_domain_name}\\Administrator,${$netbios_domain_name}\\WindowsAdmin ",
-		require => Package['samba'],
-	}
+  if($peers_size > 1)
+  {
+    if($is_first_node) {
+      exec { 'gluster volume create /export/config':
+        command => template('atomia/glusterfs/create_config_volume.erb'),
+        creates => '/var/lib/glusterd/vols/config_volume',
+        require => [ Class['glusterfs::server'], File['/export/config/vol1'] ],
+        unless  => "/usr/bin/test `/usr/sbin/gluster peer status | /bin/grep -c Hostname` -eq ${peers_size};",
+        notify  => Exec['start config volume'],
+      }
+    }
 
-	exec {'samba-join-domain':
-		command	=> "/usr/bin/net ads join -U \"WindowsAdmin%${ad_password}\"",
-		unless => "/usr/bin/net ads status -U \"WindowsAdmin%${ad_password}\"  >/dev/null 2>&1",
-		require	=> [File['/etc/samba/smb.conf'], File['/etc/samba/smbusers']]
-	}
-#WindowsAdmin
-}
+    exec { 'start config volume':
+      command     => '/usr/sbin/gluster volume start config_volume',
+      refreshonly => true
+    }
+
+    fstab::mount { '/storage/configuration':
+      ensure  => 'mounted',
+      device  => "gluster.${internal_zone}:/config_volume",
+      options => 'defaults,_netdev',
+      fstype  => 'glusterfs',
+      require => [Exec['start config volume'], File['/storage']],
+    }
+  }
+
+
+
+  # Configure Samba
+  file { '/etc/samba/smb.conf':
+    content => template('atomia/glusterfs/smb.conf.erb'),
+    require => Package['samba']
+  }
+
+  file { '/etc/samba/smbusers':
+    ensure  => present,
+    content => "root = ${netbios_domain_name}\\Administrator,${netbios_domain_name}\\WindowsAdmin ",
+    require => Package['samba'],
+  }
+
+  exec {'samba-join-domain':
+    command => "/usr/bin/net ads join -U \"WindowsAdmin%${ad_password}\"",
+    unless  => "/usr/bin/net ads status -U \"WindowsAdmin%${ad_password}\"  >/dev/null 2>&1",
+    require => [File['/etc/samba/smb.conf'], File['/etc/samba/smbusers']]
+  }
+  #WindowsAdmin
+  }

--- a/manifests/haproxy.pp
+++ b/manifests/haproxy.pp
@@ -43,267 +43,265 @@
 ##### cluster_ip_keepalive(advanced): %int
 
 class atomia::haproxy (
-	$agent_user = "haproxy",
-	$agent_password = "default_password",
-	$enable_agent = 0,
-	$certificate_sync_source = "root@fsagent:/storage/content/ssl",
-	$certificate_sync_ssh_key = "",
-	$certificate_default_cert = "",
-	$virtual_ips_interface_to_manage = "",
-	$virtual_ips_netmask = "255.255.255.0",
-	$apache_cluster_nodes = "",
-	$iis_cluster_nodes = "",
-	$mail_cluster_nodes = "",
-	$ftp_cluster_nodes = "",
-	$haproxy_nodes_hostnames = "",
-	$cluster_ip_auth_key = "default_password",
-	$cluster_ip_warntime = 5,
-	$cluster_ip_deadtime = 15,
-	$cluster_ip_initdead = 60,
-	$cluster_ip_keepalive = 2,
+  $agent_user                      = 'haproxy',
+  $agent_password                  = 'default_password',
+  $enable_agent                    = 0,
+  $certificate_sync_source         = 'root@fsagent:/storage/content/ssl',
+  $certificate_sync_ssh_key        = '',
+  $certificate_default_cert        = '',
+  $virtual_ips_interface_to_manage = '',
+  $virtual_ips_netmask             = '255.255.255.0',
+  $apache_cluster_nodes            = '',
+  $iis_cluster_nodes               = '',
+  $mail_cluster_nodes              = '',
+  $ftp_cluster_nodes               = '',
+  $haproxy_nodes_hostnames         = '',
+  $cluster_ip_auth_key             = 'default_password',
+  $cluster_ip_warntime             = 5,
+  $cluster_ip_deadtime             = 15,
+  $cluster_ip_initdead             = 60,
+  $cluster_ip_keepalive            = 2,
 ) {
 
-	if $haproxy_nodes_hostnames != "" {
-		# TODO: Figure out way to get comma separated list of hostname for all servers with this class, in reliable order.
-		$haproxy_nodes = $hostname
-	} else {
-		$haproxy_nodes = $haproxy_nodes_hostnames
-	}
+  if $haproxy_nodes_hostnames != '' {
+    # TODO: Figure out way to get comma separated list of hostname for all servers with this class, in reliable order.
+    $haproxy_nodes = $::hostname
+  } else {
+    $haproxy_nodes = $haproxy_nodes_hostnames
+  }
 
-	$apache_cluster_ip = hiera('atomia::apache_agent::cluster_ip', '')
-	$iis_cluster_ip = hiera('atomia::iis::cluster_ip', '')
-	$mail_cluster_ip = hiera('atomia::mailserver::cluster_ip', '')
-	$ftp_cluster_ip = hiera('atomia::pureftpd::ftp_cluster_ip', '')
+  $apache_cluster_ip = hiera('atomia::apache_agent::cluster_ip', '')
+  $iis_cluster_ip = hiera('atomia::iis::cluster_ip', '')
+  $mail_cluster_ip = hiera('atomia::mailserver::cluster_ip', '')
+  $ftp_cluster_ip = hiera('atomia::pureftpd::ftp_cluster_ip', '')
 
-	class { 'apt': }
+  class { 'apt': }
 
-	if $operatingsystem == "Ubuntu" {
-		package { python-software-properties: ensure => present }
+  if $::operatingsystem == 'Ubuntu' {
+    package { 'python-software-properties': ensure => present }
 
-		apt::ppa { 'ppa:vbernat/haproxy-1.5':
-			require => Package["python-software-properties"]
-		}
+    apt::ppa { 'ppa:vbernat/haproxy-1.5':
+      require => Package['python-software-properties']
+    }
 
-		package { haproxy:
-			ensure	=> present,
-			require => [ Apt::Ppa['ppa:vbernat/haproxy-1.5'] ]
-		}
+    package { 'haproxy':
+      ensure  => present,
+      require => [ Apt::Ppa['ppa:vbernat/haproxy-1.5'] ]
+    }
 
-		if $virtual_ips_interface_to_manage != "" {
-			sysctl::conf { "net.ipv4.ip_nonlocal_bind":
-				value => 1
-			}
+    if $virtual_ips_interface_to_manage != '' {
+      sysctl::conf { 'net.ipv4.ip_nonlocal_bind':
+        value => 1
+      }
 
-			exec { "enable-all-interfaces":
-				refreshonly	=> true,
-				command		=> "/sbin/ifup -a",
-				notify		=> Exec["restart-haproxy"],
-				require => Package["haproxy"],
-			}
+      exec { 'enable-all-interfaces':
+        refreshonly => true,
+        command     => '/sbin/ifup -a',
+        notify      => Exec['restart-haproxy'],
+        require     => Package['haproxy'],
+      }
 
-			haproxy::ipalias { "apache_vip":
-				interface => $virtual_ips_interface_to_manage,
-				ip => $apache_cluster_ip,
-				netmask => $virtual_ips_netmask,
-				alias_num => 1
-			}
+      haproxy::ipalias { 'apache_vip':
+        interface => $virtual_ips_interface_to_manage,
+        ip        => $apache_cluster_ip,
+        netmask   => $virtual_ips_netmask,
+        alias_num => 1
+      }
 
-			haproxy::ipalias { "iis_vip":
-				interface => $virtual_ips_interface_to_manage,
-				ip => $iis_cluster_ip,
-				netmask => $virtual_ips_netmask,
-				alias_num => 2
-			}
+      haproxy::ipalias { 'iis_vip':
+        interface => $virtual_ips_interface_to_manage,
+        ip        => $iis_cluster_ip,
+        netmask   => $virtual_ips_netmask,
+        alias_num => 2
+      }
 
-			haproxy::ipalias { "mail_vip":
-				interface => $virtual_ips_interface_to_manage,
-				ip => $mail_cluster_ip,
-				netmask => $virtual_ips_netmask,
-				alias_num => 3
-			}
+      haproxy::ipalias { 'mail_vip':
+        interface => $virtual_ips_interface_to_manage,
+        ip        => $mail_cluster_ip,
+        netmask   => $virtual_ips_netmask,
+        alias_num => 3
+      }
 
-			haproxy::ipalias { "ftp_vip":
-				interface => $virtual_ips_interface_to_manage,
-				ip => $ftp_cluster_ip,
-				netmask => $virtual_ips_netmask,
-				alias_num => 4
-			}
+      haproxy::ipalias { 'ftp_vip':
+        interface => $virtual_ips_interface_to_manage,
+        ip        => $ftp_cluster_ip,
+        netmask   => $virtual_ips_netmask,
+        alias_num => 4
+      }
 
-			file { "/etc/ha.d/ha.cf":
-				owner		=> root,
-				group		=> root,
-				mode		=> "440",
-				content => template("atomia/haproxy/ha.d/ha.cf.erb"),
-				require => Package["heartbeat"],
-				notify	=> Service["heartbeat"],
-			}
+      file { '/etc/ha.d/ha.cf':
+        owner   => 'root',
+        group   => 'root',
+        mode    => '0440',
+        content => template('atomia/haproxy/ha.d/ha.cf.erb'),
+        require => Package['heartbeat'],
+        notify  => Service['heartbeat'],
+      }
 
-			file { "/etc/ha.d/authkeys":
-				owner		=> root,
-				group		=> root,
-				mode		=> "600",
-				content => template("atomia/haproxy/ha.d/authkeys.erb"),
-				require => Package["heartbeat"],
-				notify	=> Service["heartbeat"],
-			}
+      file { '/etc/ha.d/authkeys':
+        owner   => 'root',
+        group   => 'root',
+        mode    => '0600',
+        content => template('atomia/haproxy/ha.d/authkeys.erb'),
+        require => Package['heartbeat'],
+        notify  => Service['heartbeat'],
+      }
 
-			file { "/etc/ha.d/haresources":
-				owner		=> root,
-				group		=> root,
-				mode		=> "440",
-				content => template("atomia/haproxy/ha.d/haresources.erb"),
-				require => Package["heartbeat"],
-				notify	=> Service["heartbeat"],
-			}
+      file { '/etc/ha.d/haresources':
+        owner   => 'root',
+        group   => 'root',
+        mode    => '0440',
+        content => template('atomia/haproxy/ha.d/haresources.erb'),
+        require => Package['heartbeat'],
+        notify  => Service['heartbeat'],
+      }
 
-			package { heartbeat: ensure => present }
+      package { 'heartbeat': ensure => present }
 
-			service { "heartbeat":
-				name		=> heartbeat,
-				enable		=> true,
-				ensure		=> running,
-				require		=> Package["heartbeat"],
-			}
-		}
-	} else {
-		package { haproxy: ensure => present }
-	}
+      service { 'heartbeat':
+        ensure  => running,
+        enable  => true,
+        require => Package['heartbeat'],
+      }
+    }
+  } else {
+    package { 'haproxy': ensure => present }
+  }
 
-	file { "/etc/default/haproxy":
-		source	=> "puppet:///modules/atomia/haproxy/haproxy-default",
-		require => Package["haproxy"],
-		notify	=> Exec["restart-haproxy"],
-	}
-	
-	if !defined(Exec['restart-haproxy']) {
-		exec { "restart-haproxy":
-			refreshonly	=> true,
-			command		=> "/etc/init.d/haproxy restart",
-		}
-	}
+  file { '/etc/default/haproxy':
+    source  => 'puppet:///modules/atomia/haproxy/haproxy-default',
+    require => Package['haproxy'],
+    notify  => Exec['restart-haproxy'],
+  }
 
-	if $enable_agent == 1 {
-		package { atomia-pa-haproxy: ensure => present, }
+  if !defined(Exec['restart-haproxy']) {
+    exec { 'restart-haproxy':
+      refreshonly => true,
+      command     => '/etc/init.d/haproxy restart',
+    }
+  }
 
-		$haproxy_agent_conf = template("atomia/haproxy/atomia-pa-haproxy.conf.erb")
-	
-		file { "/etc/atomia-pa-haproxy.conf":
-			owner		=> root,
-			group		=> root,
-			mode		=> "440",
-			content => $haproxy_agent_conf,
-			require => Package["atomia-pa-haproxy"],
-			notify	=> Service["atomia-pa-haproxy"],
-		}
-	
-		exec { clear-haproxy-conf:
-			path		=> ["/usr/bin", "/usr/sbin"],
-			onlyif		=> "[ x`md5sum /etc/haproxy/haproxy.cfg | cut -d ' ' -f 1` = x`grep haproxy.cfg /var/lib/dpkg/info/haproxy.md5sums | cut -d ' ' -f 1` ]",
-			command 	=> "echo '' > /etc/haproxy/haproxy.cfg",
-			provider	=> "shell"
-		}
-	
-		service { "atomia-pa-haproxy":
-			name			=> atomia-pa-haproxy,
-			enable		=> true,
-			ensure		=> running,
-			pattern		=> ".*/usr/bin/atomia-pa-haproxy",
-			require		=> Package["atomia-pa-haproxy"],
-			subscribe 	=> File["/etc/atomia-pa-haproxy.conf"]
-		}
-	} else {
-		$haproxy_conf = template("atomia/haproxy/haproxy.conf.erb")
+  if $enable_agent == 1 {
+    package { 'atomia-pa-haproxy': ensure => present, }
 
-		file { "/etc/haproxy/atomia_certificates":
-			ensure	=> directory,
-			owner	=> root,
-			group	=> root,
-			mode	=> "755",
-			require	=> Package["haproxy"]
-		}
+    $haproxy_agent_conf = template('atomia/haproxy/atomia-pa-haproxy.conf.erb')
 
-		package { "rsync":
-			ensure => present
-		}
+    file { '/etc/atomia-pa-haproxy.conf':
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0440',
+      content => $haproxy_agent_conf,
+      require => Package['atomia-pa-haproxy'],
+      notify  => Service['atomia-pa-haproxy'],
+    }
 
-		file { "/etc/haproxy/sync_certificates.sh":
-			ensure	=> file,
-			owner	=> root,
-			group	=> root,
-			mode	=> "755",
-			source	=> "puppet:///modules/atomia/haproxy/sync_certificates.sh",
-			require	=> [ Package["haproxy"], Package["rsync"] ]
-		}
+    exec { 'clear-haproxy-conf':
+      path     => ['/usr/bin', '/usr/sbin'],
+      onlyif   => "[ x`md5sum /etc/haproxy/haproxy.cfg | cut -d ' ' -f 1` = x`grep haproxy.cfg /var/lib/dpkg/info/haproxy.md5sums | cut -d ' ' -f 1` ]",
+      command  => "echo '' > /etc/haproxy/haproxy.cfg",
+      provider => 'shell'
+    }
+
+    service { 'atomia-pa-haproxy':
+      ensure    => running,
+      enable    => true,
+      pattern   => '.*/usr/bin/atomia-pa-haproxy',
+      require   => Package['atomia-pa-haproxy'],
+      subscribe => File['/etc/atomia-pa-haproxy.conf']
+    }
+  } else {
+    $haproxy_conf = template('atomia/haproxy/haproxy.conf.erb')
+
+    file { '/etc/haproxy/atomia_certificates':
+      ensure  => directory,
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0755',
+      require => Package['haproxy']
+    }
+
+    package { 'rsync':
+      ensure => present
+    }
+
+    file { '/etc/haproxy/sync_certificates.sh':
+      ensure  => file,
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0755',
+      source  => 'puppet:///modules/atomia/haproxy/sync_certificates.sh',
+      require => [ Package['haproxy'], Package['rsync'] ]
+    }
 
 
-		if $certificate_sync_ssh_key != "" {
-			file { "/root/.ssh":
-				ensure	=> directory,
-				owner	=> root,
-				group	=> root,
-				mode	=> "700",
-			}
+    if $certificate_sync_ssh_key != '' {
+      file { '/root/.ssh':
+        ensure => directory,
+        owner  => 'root',
+        group  => 'root',
+        mode   => '0700',
+      }
 
-			file { "/root/.ssh/id_rsa":
-				ensure	=> file,
-				owner	=> root,
-				group	=> root,
-				mode	=> "600",
-				content => $certificate_sync_ssh_key
-			}
-		
-			$sync_certs_cron = template("atomia/haproxy/sync_certificates.cron")
-		
-			file { "/etc/cron.d/atomia-sync-certificates":
-				ensure	=> file,
-				owner	=> root,
-				group	=> root,
-				mode	=> "644",
-				content => $sync_certs_cron,
-				require => File["/root/.ssh/id_rsa"]
-		
-			}
-		}
+      file { '/root/.ssh/id_rsa':
+        ensure  => file,
+        owner   => 'root',
+        group   => 'root',
+        mode    => '0600',
+        content => $certificate_sync_ssh_key
+      }
 
-		if $certificate_default_cert == "" {
-			file { "/etc/haproxy/atomia_certificates/default.pem":
-				source	=> "puppet:///modules/atomiacerts/certificates/wildcard_with_key.pem",
-				ensure	=> file,
-				owner	=> root,
-				group	=> root,
-				mode	=> "755",
-				require => File["/etc/haproxy/atomia_certificates"]
-			}
-		}
-	
-		file { "/etc/haproxy/haproxy.cfg":
-			require => [ Package["haproxy"], File["/etc/haproxy/atomia_certificates"] ],
-			notify	=> Exec["restart-haproxy"],
-			content => $haproxy_conf
-		}
-	}
+      $sync_certs_cron = template('atomia/haproxy/sync_certificates.cron')
+
+      file { '/etc/cron.d/atomia-sync-certificates':
+        ensure  => file,
+        owner   => 'root',
+        group   => 'root',
+        mode    => '0644',
+        content => $sync_certs_cron,
+        require => File['/root/.ssh/id_rsa']
+
+      }
+    }
+
+    if $certificate_default_cert == '' {
+      file { '/etc/haproxy/atomia_certificates/default.pem':
+        ensure  => file,
+        source  => 'puppet:///modules/atomiacerts/certificates/wildcard_with_key.pem',
+        owner   => 'root',
+        group   => 'root',
+        mode    => '0755',
+        require => File['/etc/haproxy/atomia_certificates']
+      }
+    }
+
+    file { '/etc/haproxy/haproxy.cfg':
+      require => [ Package['haproxy'], File['/etc/haproxy/atomia_certificates'] ],
+      notify  => Exec['restart-haproxy'],
+      content => $haproxy_conf
+    }
+  }
 }
 
 define haproxy::ipalias(
-        $interface = "",
-        $ip = "",
-        $netmask = "",
-        $alias_num
-        ) {
+  $alias_num,
+  $interface = '',
+  $ip        = '',
+  $netmask   = '',
+) {
 
-	if $ip != "" {
-		augeas { "haproxy_ipalias_$ip": 
-			context => "/files/etc/network/interfaces", 
-			changes => [ 
-				"set auto[child::1 = '$interface:$alias_num']/1 $interface:$alias_num", 
-				"set iface[. = '$interface:$alias_num'] $interface:$alias_num", 
-				"set iface[. = '$interface:$alias_num']/family inet", 
-				"set iface[. = '$interface:$alias_num']/method static", 
-				"set iface[. = '$interface:$alias_num']/address $ip", 
-				"set iface[. = '$interface:$alias_num']/netmask $netmask", 
-			],
-			notify => Exec["enable-all-interfaces"],
-			before => [ Package["heartbeat"], Service["heartbeat"] ]
-		}
-	}
+  if $ip != '' {
+    augeas { "haproxy_ipalias_${ip}":
+      context => '/files/etc/network/interfaces',
+      changes => [
+        "set auto[child::1 = '${interface}:${alias_num}']/1 ${interface}:${alias_num}",
+        "set iface[. = '${interface}:${alias_num}'] ${interface}:${alias_num}",
+        "set iface[. = '${interface}:${alias_num}']/family inet",
+        "set iface[. = '${interface}:${alias_num}']/method static",
+        "set iface[. = '${interface}:${alias_num}']/address ${ip}",
+        "set iface[. = '${interface}:${alias_num}']/netmask ${netmask}",
+      ],
+      notify  => Exec['enable-all-interfaces'],
+      before  => [ Package['heartbeat'], Service['heartbeat'] ]
+    }
+  }
 }

--- a/manifests/iis.pp
+++ b/manifests/iis.pp
@@ -13,72 +13,72 @@
 ##### first_node(advanced): .*
 
 class atomia::iis(
-	$sharePath = "",
-	$cluster_ip = "",
-    $first_node = $fqdn
+  $sharePath  = '',
+  $cluster_ip = '',
+  $first_node = $fqdn
 ){
 
-	$adminUser = "WindowsAdmin"
-	$adminPassword = hiera('atomia::active_directory::windows_admin_password', '')
-	$adDomain = hiera('atomia::active_directory::domain_name', '')
+  $adminUser     = 'WindowsAdmin'
+  $adminPassword = hiera('atomia::active_directory::windows_admin_password', '')
+  $adDomain      = hiera('atomia::active_directory::domain_name', '')
 
-	$dism_features_to_enable = [
-		'NetFx3', 'IIS-WebServerRole', 'IIS-WebServer', 'IIS-CommonHttpFeatures', 'IIS-Security', 'IIS-RequestFiltering',
-		'IIS-StaticContent', 'IIS-DefaultDocument', 'IIS-ApplicationDevelopment', 'IIS-NetFxExtensibility', 'IIS-ASPNET',
-		'IIS-ASP', 'IIS-CGI', 'IIS-ServerSideIncludes', 'IIS-CustomLogging', 'IIS-BasicAuthentication', 'IIS-WebServerManagementTools',
-		'IIS-ManagementConsole',
-	]
+  $dism_features_to_enable = [
+    'NetFx3', 'IIS-WebServerRole', 'IIS-WebServer', 'IIS-CommonHttpFeatures', 'IIS-Security', 'IIS-RequestFiltering',
+    'IIS-StaticContent', 'IIS-DefaultDocument', 'IIS-ApplicationDevelopment', 'IIS-NetFxExtensibility', 'IIS-ASPNET',
+    'IIS-ASP', 'IIS-CGI', 'IIS-ServerSideIncludes', 'IIS-CustomLogging', 'IIS-BasicAuthentication', 'IIS-WebServerManagementTools',
+    'IIS-ManagementConsole',
+  ]
 
-	dism { $dism_features_to_enable: ensure => present, all => true }
+  dism { $dism_features_to_enable: ensure => present, all => true }
 
-	if !defined(File['c:/install']) {
-		file { 'c:/install': ensure => 'directory' }
-	}
+  if !defined(File['c:/install']) {
+    file { 'c:/install': ensure => 'directory' }
+  }
 
-	file { 'c:/install/IISSharedConfigurationEnabler.exe':
-		ensure => 'file',
-		source => "puppet:///modules/atomia/iis/IISSharedConfigurationEnabler.exe",
-	mode	 => "0777",
-		require => File['c:/install'],
-	}
+  file { 'c:/install/IISSharedConfigurationEnabler.exe':
+    ensure  => 'file',
+    source  => 'puppet:///modules/atomia/iis/IISSharedConfigurationEnabler.exe',
+    mode    => '0777',
+    require => File['c:/install'],
+  }
 
-	file { 'c:/install/LsaStorePrivateData.exe':
-		ensure => 'file',
-		source => "puppet:///modules/atomia/iis/LsaStorePrivateData.exe",
-	mode	 => "0777",
-		require => File['c:/install'],
-	}
+  file { 'c:/install/LsaStorePrivateData.exe':
+    ensure  => 'file',
+    source  => 'puppet:///modules/atomia/iis/LsaStorePrivateData.exe',
+    mode    => '0777',
+    require => File['c:/install'],
+  }
 
-	file { 'c:/install/RegistryUnlocker.exe':
-		ensure => 'file',
-		source => "puppet:///modules/atomia/iis/RegistryUnlocker.exe",
-	mode	 => "0777",
-		require => File['c:/install'],
-	} 
+  file { 'c:/install/RegistryUnlocker.exe':
+    ensure  => 'file',
+    source  => 'puppet:///modules/atomia/iis/RegistryUnlocker.exe',
+    mode    => '0777',
+    require => File['c:/install'],
+  }
 
-	file { 'c:/install/setup_iis.ps1':
-		ensure => 'file',
-		source => "puppet:///modules/atomia/iis/setup_iis.ps1",
-		require => File['c:/install'],
-	}
+  file { 'c:/install/setup_iis.ps1':
+    ensure  => 'file',
+    source  => 'puppet:///modules/atomia/iis/setup_iis.ps1',
+    require => File['c:/install'],
+  }
 
-    if sharePath == "" {
-        $internal_zone = hiera('atomia::internaldns::zone_name','')
-        $realSharePath = '\\gluster' + $internal_zone + '\configshare\iis'
-    }
-    else
-    {
-        $realSharePath = $sharePath
-    }
+  if $sharePath == '' {
+    $internal_zone = hiera('atomia::internaldns::zone_name','')
+    $realSharePath = '\\gluster' + $internal_zone + '\configshare\iis'
+  }
+  else
+  {
+    $realSharePath = $sharePath
+  }
 
-	exec { 'setup_iis':
-		provider => powershell,
-		command => "c:/install/setup_iis.ps1 -Action 'enable' -UNCPath '${realSharePath}' -adminUser '${adDomain}\\WindowsAdmin' -adminPassword '$adminPassword'",
-		require => [File["c:/install/setup_iis.ps1"], File["c:/install/IISSharedConfigurationEnabler.exe"], File["c:/install/LsaStorePrivateData.exe"], File["c:/install/RegistryUnlocker.exe"]],
-		creates => 'c:\windows\install\installed'
-	}
-    
-	file { 'C:\ProgramData\PuppetLabs\facter\facts.d\atomia_role_iis.txt':
-	  content => 'atomia_role_1=iis',
-	}    
+  exec { 'setup_iis':
+    provider => powershell,
+    command  => "c:/install/setup_iis.ps1 -Action 'enable' -UNCPath '${realSharePath}' -adminUser '${adDomain}\\WindowsAdmin' -adminPassword '${adminPassword}'",
+    require  => [File['c:/install/setup_iis.ps1'], File['c:/install/IISSharedConfigurationEnabler.exe'], File['c:/install/LsaStorePrivateData.exe'], File['c:/install/RegistryUnlocker.exe']],
+    creates  => 'c:\windows\install\installed'
+  }
+
+  file { 'C:\ProgramData\PuppetLabs\facter\facts.d\atomia_role_iis.txt':
+    content => 'atomia_role_1=iis',
+  }
 }

--- a/manifests/installatron.pp
+++ b/manifests/installatron.pp
@@ -15,94 +15,94 @@
 ##### content_share_nfs_location(advanced): %nfs_share
 ##### installatron_hostname(advanced): .*
 class atomia::installatron (
-		$license_key,
-		$use_nfs3 = 1,
-		$content_share_nfs_location = "",
-        $installatron_hostname = $fqdn,
-        $authentication_key
-	) {
-		
-	package { [
-		'apache2',
-		'curl',
-		'perl',
-		'php5',
-		'php5-gd',
-		'libapache2-mod-php5',
-		'php5-sqlite'
-	]: ensure => installed }
+  $license_key,
+  $use_nfs3                   = 1,
+  $content_share_nfs_location = '',
+  $installatron_hostname      = $fqdn,
+  $authentication_key
+) {
 
-	if !defined(File["/storage"]) {
-		file { "/storage":
-			ensure => directory,
-		}
-	}
+  package { [
+    'apache2',
+    'curl',
+    'perl',
+    'php5',
+    'php5-gd',
+    'libapache2-mod-php5',
+    'php5-sqlite'
+  ]: ensure => installed }
 
-	
-	if $content_share_nfs_location == "" {
-		package { 'glusterfs-client': ensure => present, }
-		$internal_zone = hiera('atomia::internaldns::zone_name','')
-        fstab::mount { '/storage/content':
-            ensure  => 'mounted',
-            device  => "gluster.${internal_zone}:/web_volume",
-            options => 'defaults,_netdev',
-            fstype  => 'glusterfs',
-            require => [Package['glusterfs-client'],File["/storage"]],
-        }			
-	}
-	else {
-		atomia::nfsmount { 'mount_content':
-			use_nfs3 => $use_nfs3,
-			mount_point => '/storage/content',
-			nfs_location => $content_share_nfs_location
-		}
-        if !defined(File["/storage/content"]) {
-            file { "/storage/content":
-                ensure => directory,
-                require => File["/storage"],
-            }
-        }      
-	}
-		
+  if !defined(File['/storage']) {
+    file { '/storage':
+      ensure => directory,
+    }
+  }
 
-	service { 'apache2': 
-		ensure		=> running,
-		require		=> Package['apache2'],
-	}
 
-	exec { 'fetch-installatron-package':
-		command		=> '/usr/bin/wget http://data.installatron.com/installatron-server_latest_all.deb -O /root/installatron-server_latest_all.deb',
-		unless		=> '/bin/ls -l /root/installatron-server_latest_all.deb | /bin/grep -c installatron',
-		require		=> Package['curl'],
-		notify		=> Exec['install-installatron-package']
-	}
+  if $content_share_nfs_location == '' {
+    package { 'glusterfs-client': ensure => present, }
+    $internal_zone = hiera('atomia::internaldns::zone_name','')
+    fstab::mount { '/storage/content':
+      ensure  => 'mounted',
+      device  => "gluster.${internal_zone}:/web_volume",
+      options => 'defaults,_netdev',
+      fstype  => 'glusterfs',
+      require => [Package['glusterfs-client'],File['/storage']],
+    }
+  }
+  else {
+    atomia::nfsmount { 'mount_content':
+      use_nfs3     => $use_nfs3,
+      mount_point  => '/storage/content',
+      nfs_location => $content_share_nfs_location
+    }
+    if !defined(File['/storage/content']) {
+      file { '/storage/content':
+        ensure  => directory,
+        require => File['/storage'],
+      }
+    }
+  }
 
-	exec { 'install-installatron-package': 
-		command		=> '/etc/profile.d/installatron-key.sh && /usr/bin/dpkg -i /root/installatron-server_latest_all.deb',
-		unless		=> '/usr/bin/dpkg -l | /bin/grep -c installatron',
-		onlyif		=> '/bin/ls /root/installatron-server_latest_all.deb | /bin/grep -c installatron',
-		require		=> File['/etc/profile.d/installatron-key.sh'],
-	}
 
-	file { '/etc/apache2/sites-enabled/000-default.conf':
-		ensure		=> absent,
-		require		=> Package["apache2"],
-		notify		=> Service["apache2"]
-	}
+  service { 'apache2':
+    ensure  => running,
+    require => Package['apache2'],
+  }
 
-	file { '/etc/apache2/sites-enabled/installatron.conf':
-		ensure		=> present,
-		source		=> "puppet:///modules/atomia/installatron/vhost.conf",
-		require		=> Package["apache2"],
-		notify		=> Service["apache2"]
-	}
+  exec { 'fetch-installatron-package':
+    command => '/usr/bin/wget http://data.installatron.com/installatron-server_latest_all.deb -O /root/installatron-server_latest_all.deb',
+    unless  => '/bin/ls -l /root/installatron-server_latest_all.deb | /bin/grep -c installatron',
+    require => Package['curl'],
+    notify  => Exec['install-installatron-package']
+  }
 
-	file { '/etc/profile.d/installatron-key.sh':
-		mode		=> "0755",
-		content => "export KEY=${license_key}",
-	}
+  exec { 'install-installatron-package':
+    command => '/etc/profile.d/installatron-key.sh && /usr/bin/dpkg -i /root/installatron-server_latest_all.deb',
+    unless  => '/usr/bin/dpkg -l | /bin/grep -c installatron',
+    onlyif  => '/bin/ls /root/installatron-server_latest_all.deb | /bin/grep -c installatron',
+    require => File['/etc/profile.d/installatron-key.sh'],
+  }
 
-	file { '/usr/local/installatron/http/index.php':
-		mode	=> "0644",
-	}
+  file { '/etc/apache2/sites-enabled/000-default.conf':
+    ensure  => absent,
+    require => Package['apache2'],
+    notify  => Service['apache2']
+  }
+
+  file { '/etc/apache2/sites-enabled/installatron.conf':
+    ensure  => present,
+    source  => 'puppet:///modules/atomia/installatron/vhost.conf',
+    require => Package['apache2'],
+    notify  => Service['apache2']
+  }
+
+  file { '/etc/profile.d/installatron-key.sh':
+    mode    => '0755',
+    content => "export KEY=${license_key}",
+  }
+
+  file { '/usr/local/installatron/http/index.php':
+    mode  => '0644',
+  }
 }

--- a/manifests/internal_apps.pp
+++ b/manifests/internal_apps.pp
@@ -10,105 +10,105 @@
 
 
 class atomia::internal_apps (
-  $repository = "PublicRepository",){
+  $repository = 'PublicRepository',){
 
-  # Set ip correctly when on ec2
-  if $ec2_public_ipv4 {
-    $public_ip = $ec2_public_ipv4
-  } else {
-    $public_ip = $ipaddress_eth0
-  }
+    # Set ip correctly when on ec2
+    if $::ec2_public_ipv4 {
+      $public_ip = $::ec2_public_ipv4
+    } else {
+      $public_ip = $::ipaddress_eth0
+    }
 
-	File { source_permissions => ignore }
-    
+    File { source_permissions => ignore }
+
     file { 'c:/install/logonasaservice.ps1':
       ensure => 'file',
-      source  => "puppet:///modules/atomia/internal_apps/logonasaservice.ps1",
+      source => 'puppet:///modules/atomia/internal_apps/logonasaservice.ps1',
     }
     exec { 'set-logonasaservice':
       command => 'C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -executionpolicy remotesigned -file c:/install/logonasaservice.ps1',
       require => File['c:/install/logonasaservice.ps1'],
     }
 
-	if($repository == 'PublicRepository')
-	{
-		#Atomia Admin Panel
-		#Atomia Billing APIs
+    if($repository == 'PublicRepository')
+    {
+      #Atomia Admin Panel
+      #Atomia Billing APIs
 
-		exec {'install-actiontrail':
-			command	=> 'C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe -Executionpolicy Unrestricted -File c:/install/install_atomia_application.ps1 -repository PublicRepository -application "Atomia ActionTrail"',
-			require   => [Exec['install-setuptools'],File['unattended.ini']],
-			creates => 'C:\Program Files (x86)\Atomia\ActionTrail',
-		}
-		->
-		exec {'install-billingapis':
-			command	=> 'C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe -Executionpolicy Unrestricted -File c:/install/install_atomia_application.ps1 -repository PublicRepository -application "Atomia Billing APIs"',
-			require   => [Exec['install-actiontrail'],File['unattended.ini']],
-			creates => 'C:\Program Files (x86)\Atomia\BillingAPIs',
-		}
-		->
-		exec {'install-automationserver':
-			command	=> 'C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe -Executionpolicy Unrestricted -File c:/install/install_atomia_application.ps1 -repository PublicRepository -application "Atomia Automation Server"',
-			require   => [Exec['install-actiontrail'],File['unattended.ini']],
-			creates => 'C:\Program Files (x86)\Atomia\AutomationServer\AutomationServerEngine',
-		}
-		->
-		exec {'install-cloudhostingpack':
-			command	=> 'C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe -Executionpolicy Unrestricted -File c:/install/install_atomia_application.ps1 -repository PublicRepository -application "Atomia CloudHosting Modules"',
-			require   => [Exec['install-automationserver'],File['unattended.ini']],
-			creates => 'C:\Program Files (x86)\Atomia\AutomationServer\Common\Modules\Atomia.Provisioning.Modules.Common.dll',
-		}
-		->
-		exec {'install-adminpanel':
-			command	=> 'C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe -Executionpolicy Unrestricted -File c:/install/install_atomia_application.ps1 -repository PublicRepository -application "Atomia Admin Panel"',
-			require   => [Exec['install-actiontrail'],File['unattended.ini']],
-			creates => 'C:\Program Files (x86)\Atomia\AdminPanel',
-		}
+      exec {'install-actiontrail':
+        command => 'C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe -Executionpolicy Unrestricted -File c:/install/install_atomia_application.ps1 -repository PublicRepository -application "Atomia ActionTrail"',
+        require => [Exec['install-setuptools'],File['unattended.ini']],
+        creates => 'C:\Program Files (x86)\Atomia\ActionTrail',
+      }
+    ->
+    exec {'install-billingapis':
+      command => 'C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe -Executionpolicy Unrestricted -File c:/install/install_atomia_application.ps1 -repository PublicRepository -application "Atomia Billing APIs"',
+      require => [Exec['install-actiontrail'],File['unattended.ini']],
+      creates => 'C:\Program Files (x86)\Atomia\BillingAPIs',
+    }
+  ->
+  exec {'install-automationserver':
+    command => 'C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe -Executionpolicy Unrestricted -File c:/install/install_atomia_application.ps1 -repository PublicRepository -application "Atomia Automation Server"',
+    require => [Exec['install-actiontrail'],File['unattended.ini']],
+    creates => 'C:\Program Files (x86)\Atomia\AutomationServer\AutomationServerEngine',
+  }
+->
+exec {'install-cloudhostingpack':
+  command => 'C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe -Executionpolicy Unrestricted -File c:/install/install_atomia_application.ps1 -repository PublicRepository -application "Atomia CloudHosting Modules"',
+  require => [Exec['install-automationserver'],File['unattended.ini']],
+  creates => 'C:\Program Files (x86)\Atomia\AutomationServer\Common\Modules\Atomia.Provisioning.Modules.Common.dll',
+}
+    ->
+    exec {'install-adminpanel':
+      command => 'C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe -Executionpolicy Unrestricted -File c:/install/install_atomia_application.ps1 -repository PublicRepository -application "Atomia Admin Panel"',
+      require => [Exec['install-actiontrail'],File['unattended.ini']],
+      creates => 'C:\Program Files (x86)\Atomia\AdminPanel',
+    }
 
-	}
-	else
-	{
-		exec {'install-actiontrail':
-			command	=> 'C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe -Executionpolicy Unrestricted -File c:/install/install_atomia_application.ps1 -repository TestRepository -application "Atomia ActionTrail"',
-			require   => [Exec['install-setuptools'],File['unattended.ini']],
-			creates => 'C:\Program Files (x86)\Atomia\ActionTrail',
-		}
-		->
-		exec {'install-billingapis':
-			command	=> 'C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe -Executionpolicy Unrestricted -File c:/install/install_atomia_application.ps1 -repository TestRepository -application "Atomia Billing APIs"',
-			require   => [Exec['install-actiontrail'],File['unattended.ini']],
-			creates => 'C:\Program Files (x86)\Atomia\BillingAPIs',
-		}
-		->
-		exec {'install-automationserver':
-			command	=> 'C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe -Executionpolicy Unrestricted -File c:/install/install_atomia_application.ps1 -repository TestRepository -application "Atomia Automation Server"',
-			require   => [Exec['install-actiontrail'],File['unattended.ini']],
-			creates => 'C:\Program Files (x86)\Atomia\AutomationServer\AutomationServerEngine',
-		}
-		->
-		exec {'install-cloudhostingpack':
-			command	=> 'C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe -Executionpolicy Unrestricted -File c:/install/install_atomia_application.ps1 -repository TestRepository -application "Atomia CloudHosting Modules"',
-			require   => [Exec['install-automationserver'],File['unattended.ini']],
-			creates => 'C:\Program Files (x86)\Atomia\AutomationServer\Common\Modules\Atomia.Provisioning.Modules.Common.dll',
-		}
-		->
-		exec {'install-adminpanel':
-			command	=> 'C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe -Executionpolicy Unrestricted -File c:/install/install_atomia_application.ps1 -repository TestRepository -application "Atomia Admin Panel"',
-			require   => [Exec['install-actiontrail'],File['unattended.ini']],
-			creates => 'C:\Program Files (x86)\Atomia\AdminPanel',
-		}
-	}
+    }
+    else
+    {
+      exec {'install-actiontrail':
+        command => 'C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe -Executionpolicy Unrestricted -File c:/install/install_atomia_application.ps1 -repository TestRepository -application "Atomia ActionTrail"',
+        require => [Exec['install-setuptools'],File['unattended.ini']],
+        creates => 'C:\Program Files (x86)\Atomia\ActionTrail',
+      }
+    ->
+    exec {'install-billingapis':
+      command => 'C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe -Executionpolicy Unrestricted -File c:/install/install_atomia_application.ps1 -repository TestRepository -application "Atomia Billing APIs"',
+      require => [Exec['install-actiontrail'],File['unattended.ini']],
+      creates => 'C:\Program Files (x86)\Atomia\BillingAPIs',
+    }
+  ->
+  exec {'install-automationserver':
+    command => 'C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe -Executionpolicy Unrestricted -File c:/install/install_atomia_application.ps1 -repository TestRepository -application "Atomia Automation Server"',
+    require => [Exec['install-actiontrail'],File['unattended.ini']],
+    creates => 'C:\Program Files (x86)\Atomia\AutomationServer\AutomationServerEngine',
+  }
+->
+exec {'install-cloudhostingpack':
+  command => 'C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe -Executionpolicy Unrestricted -File c:/install/install_atomia_application.ps1 -repository TestRepository -application "Atomia CloudHosting Modules"',
+  require => [Exec['install-automationserver'],File['unattended.ini']],
+  creates => 'C:\Program Files (x86)\Atomia\AutomationServer\Common\Modules\Atomia.Provisioning.Modules.Common.dll',
+}
+    ->
+    exec {'install-adminpanel':
+      command => 'C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe -Executionpolicy Unrestricted -File c:/install/install_atomia_application.ps1 -repository TestRepository -application "Atomia Admin Panel"',
+      require => [Exec['install-actiontrail'],File['unattended.ini']],
+      creates => 'C:\Program Files (x86)\Atomia\AdminPanel',
+    }
+    }
 
-	file { 'C:\ProgramData\PuppetLabs\facter\facts.d\atomia_role_internal.txt':
-	  content => 'atomia_role_1=internal_apps',
-	}
-    
+    file { 'C:\ProgramData\PuppetLabs\facter\facts.d\atomia_role_internal.txt':
+      content => 'atomia_role_1=internal_apps',
+    }
+
     # Automation Server default transformations
 
-     file { 'C:/Program Files (x86)/Atomia/AutomationServer/Common/ProvisioningDescriptions/Transformation Files/ProvisioningDescription.Installatron.xml' :
-      ensure => 'file',
-      content  => template('atomia/transformations/ProvisioningDescriptions/ProvisioningDescription.Installatron.xml.erb'),
+    file { 'C:/Program Files (x86)/Atomia/AutomationServer/Common/ProvisioningDescriptions/Transformation Files/ProvisioningDescription.Installatron.xml' :
+      ensure  => 'file',
+      content => template('atomia/transformations/ProvisioningDescriptions/ProvisioningDescription.Installatron.xml.erb'),
       require => Exec['install-automationserver'],
     }
-        
-}
+
+  }

--- a/manifests/internal_mailserver.pp
+++ b/manifests/internal_mailserver.pp
@@ -10,21 +10,21 @@
 
 
 class atomia::internal_mailserver (
-	$allow_subnet = "10.0.0.0/24",
+  $allow_subnet = '10.0.0.0/24',
 ){
-	package { postfix: ensure => present }
-	
-	# Modify configuration with Augeas
-	
-	augeas { 'postfix-main-cf':
-		context => '/files/etc/postfix/main.cf',
-		changes => [
-			"set mynetworks ${allow_subnet}", 
-		],
-		notify	=> Service['postfix']
-	}
-	
-	service { postfix:
-		ensure	=> running
-	}
+  package { 'postfix': ensure => present }
+
+  # Modify configuration with Augeas
+
+  augeas { 'postfix-main-cf':
+    context => '/files/etc/postfix/main.cf',
+    changes => [
+      "set mynetworks ${allow_subnet}",
+    ],
+    notify  => Service['postfix']
+  }
+
+  service { 'postfix':
+    ensure  => running
+  }
 }

--- a/manifests/internaldns.pp
+++ b/manifests/internaldns.pp
@@ -11,56 +11,60 @@
 ##### ip_address(advanced): .*
 
 class atomia::internaldns (
-	$zone_name     		= "",
-	$ip_address				= "$ipaddress"
+  $zone_name         = '',
+  $ip_address        = $ipaddress
 ){
 
 
-	class { 'bind': 
-		default_view => {
-			'recursion' => 'yes',
-		}
-	}
+  class { 'bind':
+    default_view => {
+      'recursion' => 'yes',
+    }
+  }
 
-	bind::zone {"$zone_name":
-	  zone_contact => "contact.${$zone_name}",
-	  zone_ns      => ["ns0.${$zone_name}"],
-	  zone_serial  => '2012112901',
-	  zone_ttl     => '604800',
-	  zone_origin  => "${$zone_name}",
-	}
+  bind::zone {$zone_name:
+    zone_contact => "contact.${zone_name}",
+    zone_ns      => ["ns0.${zone_name}"],
+    zone_serial  => '2012112901',
+    zone_ttl     => '604800',
+    zone_origin  => $zone_name,
+  }
 
-	$ad_domain = hiera('atomia::active_directory::domain_name', '')
-	if($ad_domain != '') {
-		bind::zone {"$ad_domain":
-			zone_type		=> 'forward',
-			zone_ttl     => '604800',
-			zone_forwarders	=> '52.30.144.80'
-		}
-	}
+  $ad_domain = hiera('atomia::active_directory::domain_name', '')
+  if($ad_domain != '') {
+    bind::zone {$ad_domain:
+      zone_type       => 'forward',
+      zone_ttl        => '604800',
+      zone_forwarders => '52.30.144.80'
+    }
+  }
 
-	# Set ip correctly when on ec2
-	if $ec2_public_ipv4 {
-	  $public_ip = $ec2_public_ipv4
-	} else {
-	  $public_ip = $ipaddress_eth0
-	}
+  # Set ip correctly when on ec2
+  if $::ec2_public_ipv4 {
+    $public_ip = $::ec2_public_ipv4
+  } else {
+    $public_ip = $::ipaddress_eth0
+  }
 
-	@@bind::a { 'Hosts in zone':
-	  ensure    => 'present',
-	  zone      => "${$zone_name}",
-	  ptr       => false,
-	  hash_data => {
-	    'ns0' => { owner => "${public_ip}" },
-	    'intdns' => { owner => "${public_ip}" },
-	  },
-	}
+  @@bind::a { 'Hosts in zone':
+    ensure    => 'present',
+    zone      => $zone_name,
+    ptr       => false,
+    hash_data => {
+      'ns0'    => {
+        owner => $public_ip
+      },
+      'intdns' => {
+      owner => $public_ip
+      },
+    },
+  }
 
-	Bind::A <<| |>>
+  Bind::A <<| |>>
 
-	exec { "restart_bind":
-		command => "/etc/init.d/bind9 restart",
-		refreshonly => true,
-	}
+  exec { 'restart_bind':
+    command     => '/etc/init.d/bind9 restart',
+    refreshonly => true,
+  }
 
 }

--- a/manifests/linux_base.pp
+++ b/manifests/linux_base.pp
@@ -1,110 +1,110 @@
 class atomia::linux_base {
 
-    package { 'sudo': ensure => present }
+  package { 'sudo': ensure => present }
 
-    include '::ntp'
+  include '::ntp'
 
-    $internal_dns = hiera('atomia::internaldns::ip_address', '')
+  $internal_dns = hiera('atomia::internaldns::ip_address', '')
 
-    $factfile = '/etc/facter/facts.d/ad_server.txt'
-   
-    if !defined(File['/etc/facter']){
-      file { '/etc/facter':
-        ensure  => directory,
+  $factfile = '/etc/facter/facts.d/ad_server.txt'
+
+  if !defined(File['/etc/facter']){
+    file { '/etc/facter':
+      ensure  => directory,
+    }
+  }
+
+  if !defined(File['/etc/facter/facts.d']){
+    file { '/etc/facter/facts.d':
+      ensure  => directory,
+      require => File['/etc/facter'],
+    }
+  }
+
+  if($::atomia_role_1 != 'nagios_server' and $::atomia_role_1 != 'atomia_database'){
+    concat {  $factfile:
+      ensure  => present,
+      force   => true,
+      require => File['/etc/facter/facts.d'],
+    }
+
+    Concat::Fragment <<| tag == 'dc_ip_linux' |>>
+  }
+  if $internal_dns != '' {
+    if ($::atomia_role_1 != 'glusterfs') and ($::atomia_role_1 != 'glusterfs_replica') {
+      class { 'resolv_conf':
+        nameservers => [$internal_dns],
       }
     }
-    
-    if !defined(File['/etc/facter/facts.d']){
-      file { '/etc/facter/facts.d':
-        ensure  => directory,
-        require => File['/etc/facter'],
-      }
-    }
-    
-    if($atomia_role_1 != 'nagios_server' and $atomia_role_1 != 'atomia_database'){    
-        concat {  $factfile:
-        ensure => present,
-        force => true,
-        require => File['/etc/facter/facts.d'],
-        }    
-        
-        Concat::Fragment <<| tag == 'dc_ip_linux' |>>
-    }
-    if $internal_dns != '' {
-      if ($atomia_role_1 != "glusterfs") and ($atomia_role_1 != "glusterfs_replica") {
+    else {
+      if($atomia::active_directory::ad_server){
         class { 'resolv_conf':
-          nameservers => ["${internal_dns}"],
+          nameservers => [$atomia::active_directory::ad_server],
         }
       }
-      else {
-        if($ad_server){
-          class { 'resolv_conf':
-            nameservers => ["${ad_server}"],
-          }
-        }
-      }
-	  
-	  # Add Puppetmaster to local hosts file
-	  host { 'puppetmaster-host':
-	  	name 	=> hiera('atomia::config::puppet_hostname'),
-      ensure 	=> present,
-      ip 		=> hiera('atomia::config::puppet_ip'),
-	  }
-
-      Host <<| |>>
     }
+
+    # Add Puppetmaster to local hosts file
+    host { 'puppetmaster-host':
+      ensure => present,
+      name   => hiera('atomia::config::puppet_hostname'),
+      ip     => hiera('atomia::config::puppet_ip'),
+    }
+
+    Host <<| |>>
+  }
 }
 
-define atomia::hostname::register ($content="", $order='10') {
+define atomia::hostname::register ($content='', $order='10') {
   $factfile = '/etc/hosts'
 
   @@concat::fragment {"hostnames_${content}":
-      target => $factfile,
-      content => "${content} ",
-      tag => 'hosts_file',
-      order => 3
-    }
+    target  => $factfile,
+    content => "${content} ",
+    tag     => 'hosts_file',
+    order   => 3
+  }
 
 }
 
 define limits::conf (
-	$domain = "root",
-	$type = "soft",
-	$item = "nofile",
-	$value = "10000"
-	) {
+  $domain = 'root',
+  $type = 'soft',
+  $item = 'nofile',
+  $value = '10000'
+) {
 
-	$key = "$domain/$type/$item"
-	$context = "/files/etc/security/limits.conf"
-	$path_list	= "domain[.=\"$domain\"][./type=\"$type\" and ./item=\"$item\"]"
-	$path_exact = "domain[.=\"$domain\"][./type=\"$type\" and ./item=\"$item\" and ./value=\"$value\"]"
+  $key = "${domain}/${type}/${item}"
+  $context = '/files/etc/security/limits.conf'
+  $path_list  = "domain[.=\"${domain}\"][./type=\"${type}\" and ./item=\"${item}\"]"
+  $path_exact = "domain[.=\"${domain}\"][./type=\"${type}\" and ./item=\"${item}\" and ./value=\"${value}\"]"
 
-	augeas { "limits_conf/$key":
-		 context => "$context",
-		 onlyif  => "match $path_exact size != 1",
-		 changes => [
-			 # remove all matching to the $domain, $type, $item, for any $value
-			 "rm $path_list",
-			 # insert new node at the end of tree
-			 "set domain[last()+1] $domain",
-			 # assign values to the new node
-			 "set domain[last()]/type $type",
-			 "set domain[last()]/item $item",
-			 "set domain[last()]/value $value",
-		 ],
-	 }
+  augeas { "limits_conf/${key}":
+    context => $context,
+    onlyif  => "match ${path_exact} size != 1",
+    changes => [
+      # remove all matching to the $domain, $type, $item, for any $value
+      "rm ${path_list}",
+      # insert new node at the end of tree
+      "set domain[last()+1] ${domain}",
+      # assign values to the new node
+      "set domain[last()]/type ${type}",
+      "set domain[last()]/item ${item}",
+      "set domain[last()]/value ${value}",
+    ],
+  }
 }
 
 define sysctl::conf ($value) {
-	exec { "/sbin/sysctl -p":
-		alias => "sysctl",
-		refreshonly => true,
-	}
+  exec { '/sbin/sysctl -p':
+    alias       => 'sysctl',
+    refreshonly => true,
+  }
 
-	augeas { "sysctl_conf/$title":
-		context => "/files/etc/sysctl.conf",
-		onlyif  => "get $title != '$value'",
-		changes => "set $title '$value'",
-		notify  => Exec["sysctl"],
-	}
-} 
+  augeas { "sysctl_conf/${title}":
+    context => '/files/etc/sysctl.conf',
+    onlyif  => "get ${title} != '${value}'",
+    changes => "set ${title} '${value}'",
+    notify  => Exec['sysctl'],
+  }
+}

--- a/manifests/mongodb.pp
+++ b/manifests/mongodb.pp
@@ -1,24 +1,24 @@
 class atomia::mongodb {
-  if $operatingsystem == "Debian" {
-    $mongorepo = "deb http://downloads-distro.mongodb.org/repo/debian-sysvinit dist 10gen"
+  if $::operatingsystem == 'Debian' {
+    $mongorepo = 'deb http://downloads-distro.mongodb.org/repo/debian-sysvinit dist 10gen'
   } else {
-    $mongorepo = "deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen"
+    $mongorepo = 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen'
   }
 
-  file { "/etc/apt/sources.list.d/10gen.list":
-    owner   => root,
-    group   => root,
-    mode    => "440",
+  file { '/etc/apt/sources.list.d/10gen.list':
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0440',
     content => $mongorepo
   }
 
-  exec { "add keyserver":
-    command     => "/usr/bin/apt-key adv --keyserver keyserver.ubuntu.com --recv 7F0CEB10;apt-get update",
-    onlyif      => ["/usr/bin/test -f /etc/apt/sources.list.d/10gen.list"],
-    subscribe   => File["/etc/apt/sources.list.d/10gen.list"],
+  exec { 'add keyserver':
+    command     => '/usr/bin/apt-key adv --keyserver keyserver.ubuntu.com --recv 7F0CEB10;apt-get update',
+    onlyif      => ['/usr/bin/test -f /etc/apt/sources.list.d/10gen.list'],
+    subscribe   => File['/etc/apt/sources.list.d/10gen.list'],
     refreshonly => true
   }
 
-  package { "mongodb-10gen": ensure => present }
+  package { 'mongodb-10gen': ensure => present }
 
 }

--- a/manifests/mssql.pp
+++ b/manifests/mssql.pp
@@ -6,7 +6,7 @@
 #### mssql_username: The username of the MySQL user that automation server provisions databases through.
 #### mssql_password: The password for the MySQL user that automation server provisions databases through.
 #### server_ips: Comma separated list of all mysql servers ip addresses
-#### product_key: Your license key for MSSQL 
+#### product_key: Your license key for MSSQL
 #### isopath: The absolute path to the MSSQL iso
 
 ### Validations
@@ -17,23 +17,23 @@
 ##### isopath: .*
 
 class atomia::mssql (
-	$mssql_username = "AtomiaAdmin",
-	$mssql_password,
-    $server_ips = "",
-    $product_key,
-    $isopath,
-	){
+  $mssql_username  = 'AtomiaAdmin',
+  $mssql_password,
+  $server_ips      = '',
+  $product_key,
+  $isopath,
+){
 
-    class {'windows_sql':
-        features            => 'SQL,RS_SHP,RS_SHPWFE,TOOLS',
-        pid                 => $product_key,
-        sqlsysadminaccounts => $mssql_username,
-        agtsvcaccount       => 'svc_sqlagt',
-        isopath             => $isopath,
-        sqlsvcaccount       => 'svc_sqlsvc',
-        securitymode        => 'sql',
-        sapwd               => $mssql_password,
-        mode                => 'master',
-    }        
-        
-} 
+  class {'windows_sql':
+    features            => 'SQL,RS_SHP,RS_SHPWFE,TOOLS',
+    pid                 => $product_key,
+    sqlsysadminaccounts => $mssql_username,
+    agtsvcaccount       => 'svc_sqlagt',
+    isopath             => $isopath,
+    sqlsvcaccount       => 'svc_sqlsvc',
+    securitymode        => 'sql',
+    sapwd               => $mssql_password,
+    mode                => 'master',
+  }
+
+}

--- a/manifests/mysql.pp
+++ b/manifests/mysql.pp
@@ -17,46 +17,49 @@
 ##### server_ips: .*
 
 class atomia::mysql (
-	$mysql_username = "automationserver",
-	$mysql_password,
-	$mysql_root_password,
-	$provisioning_host = "%",
-    $server_ips = "",
-	){
+  $mysql_username       = 'automationserver',
+  $mysql_password,
+  $mysql_root_password,
+  $provisioning_host    = '%',
+  $server_ips           = '',
+){
 
-	# TODO: Consider changing % to hostname for automation server in internal zone when this is setup.
+  # TODO: Consider changing % to hostname for automation server in internal zone when this is setup.
 
-	class { '::mysql::server':
-		restart			=> true,
-		root_password		=> $mysql_root_password,
-		remove_default_accounts	=> true,
-  		override_options	=> { 'mysqld' => { 'bind_address' => '*' } }
-	}	
+  class { '::mysql::server':
+    restart                 => true,
+    root_password           => $mysql_root_password,
+    remove_default_accounts => true,
+    override_options        => {
+    'mysqld' => {
+      'bind_address' => '*' }
+    }
+  }
 
-	mysql_user { "$mysql_username@$provisioning_host":
- 		ensure          => 'present',
-		password_hash	=> mysql_password($mysql_password),
-	}
+  mysql_user { "${mysql_username}@${provisioning_host}":
+    ensure        => 'present',
+    password_hash => mysql_password($mysql_password),
+  }
 
-	mysql_grant { "$mysql_username@$provisioning_host/*.*":
-  		ensure     => 'present',
-  		options    => ['GRANT'],
-  		privileges => ['ALL'],
-  		table      => '*.*',
-  		user       => "$mysql_username@$provisioning_host",
-	}
+  mysql_grant { "${mysql_username}@${provisioning_host}/*.*":
+    ensure     => 'present',
+    options    => ['GRANT'],
+    privileges => ['ALL'],
+    table      => '*.*',
+    user       => "${mysql_username}@${provisioning_host}",
+  }
 
-	limits::conf { "soft-file-limit":
-		domain	=> '*',
-		type	=> 'soft',
-		item	=> 'nofile',
-		value	=> 65535
-	}
+  limits::conf { 'soft-file-limit':
+    domain => '*',
+    type   => 'soft',
+    item   => 'nofile',
+    value  => 65535
+  }
 
-	limits::conf { "hard-file-limit":
-		domain	=> '*',
-		type	=> 'hard',
-		item	=> 'nofile',
-		value	=> 65535
-	}
+  limits::conf { 'hard-file-limit':
+    domain => '*',
+    type   => 'hard',
+    item   => 'nofile',
+    value  => 65535
+  }
 }

--- a/manifests/nagios/client.pp
+++ b/manifests/nagios/client.pp
@@ -1,178 +1,184 @@
 class atomia::nagios::client(
-    $username           = "nagios",
-    $password           = "nagios",
-    $public_ip          = $ipaddress_eth0,
-    $atomia_account     = "100001",
-    $apache_agent_class = "atomia::nagios::client::apache_agent",
-    $atomiadns_master_class = "atomia::nagios::client::atomiadns_master",
-    $nameserver_class       = "atomia::nagios::client::nameserver",
-    $fsagent_class          = "atomia::nagios::client::fsagent",
-    $awstats_class          = "atomia::nagios::client::awstats",
-    $domainreg_class        = "atomia::nagios::client::domainreg",
-    $internaldns_class      = "atomia::nagios::client::internaldns",
-    $active_directory_class = "atomia::nagios::client::active_directory",
-    $glusterfs_class        = "atomia::nagios::client::glusterfs",
-    $internal_mailserver_class = "atomia::nagios::client::internal_mailserver",
-    $atomia_database_class  = "atomia::nagios::client::atomia_database",
-    $internal_apps_class = "atomia::nagios::client::internal_apps",
-    $public_apps_class = "atomia::nagios::client::public_apps",
-    $iis_class = "atomia::nagios::client::iis",
-    $daggre_class = "atomia::nagios::client::daggre",
-    $cronagent_class = "atomia::nagios::client::cronagent",
-    $pureftpd_class = "atomia::nagios::client::pureftpd",
-    $mailserver_class = "atomia::nagios::client::mailserver",
+  $username                  = 'nagios',
+  $password                  = 'nagios',
+  $public_ip                 = ipaddress_eth0,
+  $atomia_account            = '100001',
+  $apache_agent_class        = 'atomia::nagios::client::apache_agent',
+  $atomiadns_master_class    = 'atomia::nagios::client::atomiadns_master',
+  $nameserver_class          = 'atomia::nagios::client::nameserver',
+  $fsagent_class             = 'atomia::nagios::client::fsagent',
+  $awstats_class             = 'atomia::nagios::client::awstats',
+  $domainreg_class           = 'atomia::nagios::client::domainreg',
+  $internaldns_class         = 'atomia::nagios::client::internaldns',
+  $active_directory_class    = 'atomia::nagios::client::active_directory',
+  $glusterfs_class           = 'atomia::nagios::client::glusterfs',
+  $internal_mailserver_class = 'atomia::nagios::client::internal_mailserver',
+  $atomia_database_class     = 'atomia::nagios::client::atomia_database',
+  $internal_apps_class       = 'atomia::nagios::client::internal_apps',
+  $public_apps_class         = 'atomia::nagios::client::public_apps',
+  $iis_class                 = 'atomia::nagios::client::iis',
+  $daggre_class              = 'atomia::nagios::client::daggre',
+  $cronagent_class           = 'atomia::nagios::client::cronagent',
+  $pureftpd_class            = 'atomia::nagios::client::pureftpd',
+  $mailserver_class          = 'atomia::nagios::client::mailserver',
 ) {
 
-  $atomia_domain = hiera('atomia::config::atomia_domain')
+  $atomia_domain   = hiera('atomia::config::atomia_domain')
   $internal_domain = hiera('atomia::internaldns::zone_name','')
-  if $ec2_public_ipv4 {
-    $ip_address = $ec2_public_ipv4
+  if $::ec2_public_ipv4 {
+    $ip_address = $::ec2_public_ipv4
   } else {
     $ip_address = $public_ip
   }
 
-	# Deploy on Windows.
-	if $operatingsystem == 'windows' {
-		class { 'nsclient':
-            allowed_hosts => ["0.0.0.0/0"],
-            package_source_location => 'https://github.com/mickem/nscp/releases/download/0.4.4.15',
-            package_source => 'NSCP-0.4.4.15-x64.msi',
-		}
+  # Deploy on Windows.
+  if $::operatingsystem == 'windows' {
+    class { 'nsclient':
+      allowed_hosts           => ['0.0.0.0/0'],
+      package_source_location => 'https://github.com/mickem/nscp/releases/download/0.4.4.15',
+      package_source          => 'NSCP-0.4.4.15-x64.msi',
+    }
 
-    case $atomia_role_1 {
-      
+    case $::atomia_role_1 {
+
       'active_directory':   {
-          class { "${active_directory_class}": 
-            hostgroup => 'windows-all,windows-domain-controllers'
-           }
+        class { $active_directory_class:
+          hostgroup => 'windows-all,windows-domain-controllers'
         }
+      }
       'active_directory_replica':   {
-          class { "${active_directory_class}": 
-            hostgroup => 'windows-all,windows-domain-controllers'
-           }
+        class { $active_directory_class:
+          hostgroup => 'windows-all,windows-domain-controllers'
         }
-        'public_apps': {
-           class { "${public_apps_class}": 
-            hostgroup => 'windows-all'
-           }           
-        }   
-        'internal_apps': {
-           class { "${internal_apps_class}": 
-            hostgroup => 'windows-all'
-           }           
+      }
+      'public_apps': {
+        class { $public_apps_class:
+          hostgroup => 'windows-all'
         }
-        'iis': {
-           class { "${iis_class}": 
-            hostgroup => 'windows-all'
-           }           
-        }                                   
-    }       
+      }
+      'internal_apps': {
+        class { $internal_apps_class:
+          hostgroup => 'windows-all'
+        }
+      }
+      'iis': {
+        class { $iis_class:
+          hostgroup => 'windows-all'
+        }
+      }
+      default: {
+        warning('Unsupported config')
+      }
+    }
 
-	} else {
-	# Deploy on other OS (Linux)
+  } else {
+    # Deploy on other OS (Linux)
     package { [
       'nagios-nrpe-server',
-  		'libconfig-json-perl',
-  		'libdatetime-format-iso8601-perl'
+      'libconfig-json-perl',
+      'libdatetime-format-iso8601-perl'
     ]:
-        ensure => installed,
+      ensure => installed,
     }
 
     if ! defined(Package['libwww-mechanize-perl']) {
-        package { 'libwww-mechanize-perl':
-            ensure => installed,
-        }
+      package { 'libwww-mechanize-perl':
+        ensure => installed,
+      }
     }
 
     # Define hostgroups based on custom fact
-    case $atomia_role_1 {
-        'domainreg':            {
-          $hostgroup = 'linux-atomia-agents,linux-all'
-          class { "${domainreg_class}": }
-        }
+    case $::atomia_role_1 {
+      'domainreg':            {
+        $hostgroup = 'linux-atomia-agents,linux-all'
+        class { $domainreg_class: }
+      }
 
-        'internaldns':            {
-          $hostgroup = 'linux-all'
-          class { "${internaldns_class}": }
-        }
+      'internaldns':            {
+        $hostgroup = 'linux-all'
+        class { $internaldns_class: }
+      }
 
-        'apache_agent': {
-          $hostgroup = 'linux-customer-webservers,linux-all'
-          class { "${$apache_agent_class}": }
-        }
+      'apache_agent': {
+        $hostgroup = 'linux-customer-webservers,linux-all'
+        class { $apache_agent_class: }
+      }
 
-        'atomiadns': {
-          $hostgroup = 'linux-dns,linux-all'
-          class { "${atomiadns_master_class}": }
-        }
+      'atomiadns': {
+        $hostgroup = 'linux-dns,linux-all'
+        class { $atomiadns_master_class: }
+      }
 
-        'atomiadns_powerdns': {
-          $hostgroup = 'linux-dns,linux-all'
-          class { "${nameserver_class}": }
-        }
+      'atomiadns_powerdns': {
+        $hostgroup = 'linux-dns,linux-all'
+        class { $nameserver_class: }
+      }
 
-        'awstats': {
-          $hostgroup = 'linux-atomia-agents,linux-all'
-          class { "${awstats_class}": }
-        }
+      'awstats': {
+        $hostgroup = 'linux-atomia-agents,linux-all'
+        class { $awstats_class: }
+      }
 
-        'cronagent':              {
-          $hostgroup = 'linux-atomia-agents,linux-all'
-          class { "${cronagent_class}":
-          }
+      'cronagent':              {
+        $hostgroup = 'linux-atomia-agents,linux-all'
+        class { $cronagent_class:
         }
-        'daggre':              {
-          $hostgroup = 'linux-atomia-agents,linux-all'
-          class { "${daggre_class}":
-          }
+      }
+      'daggre':              {
+        $hostgroup = 'linux-atomia-agents,linux-all'
+        class { $daggre_class:
         }
-        'fsagent':              {
-          $hostgroup = 'linux-atomia-agents,linux-all'
-          class { "${fsagent_class}":
-              account_used_for_checks => $atomia_account
-          }
+      }
+      'fsagent':              {
+        $hostgroup = 'linux-atomia-agents,linux-all'
+        class { $fsagent_class:
+          account_used_for_checks => $atomia_account
         }
-        'nameserver':           { $hostgroup = 'linux-dns,linux-all'}
-        'pureftpd': {
-          $hostgroup = 'linux-all'
-          class { "${pureftpd_class}": }
-         }
-         'pureftpd_slave': {
-          $hostgroup = 'linux-all'
-          class { "${pureftpd_class}": }
-         }        
-        'haproxy':              { $hostgroup = 'linux-atomia-agents,linux-all'}
-        'iis':                  { $hostgroup = 'linux-atomia-agents,linux-all'}
-        'installatron':         { $hostgroup = 'linux-atomia-agents,linux-all'}
-        'glusterfs': {
-          $hostgroup = 'linux-all'
-          class { "${mailserver_class}": }
-         }
-        'mysql':                { $hostgroup = 'linux-atomia-agents,linux-all'}
-        'phpmyadmin':           { $hostgroup = 'linux-atomia-agents,linux-all'}
-        'postgresql':           { $hostgroup = 'linux-atomia-agents,linux-all'}
-        'glusterfs': {
-          $hostgroup = 'linux-all'
-          class { "${glusterfs_class}": }
-         }
-        'glusterfs_replica': {
-          $hostgroup = 'linux-all'
-          class { "${glusterfs_class}": }
-         }
-        'internal_mailserver': {
-          $hostgroup = 'linux-all'
-          class { "${internal_mailserver_class}": }
-         }    
-        'atomia_database': {
-          $hostgroup = 'linux-all'
-          class { "${atomia_database_class}": }
-         }                      
+      }
+      'nameserver':           { $hostgroup = 'linux-dns,linux-all'}
+      'pureftpd': {
+        $hostgroup = 'linux-all'
+        class { $pureftpd_class: }
+      }
+      'pureftpd_slave': {
+        $hostgroup = 'linux-all'
+        class { $pureftpd_class: }
+      }
+      'haproxy':              { $hostgroup = 'linux-atomia-agents,linux-all'}
+      'iis':                  { $hostgroup = 'linux-atomia-agents,linux-all'}
+      'installatron':         { $hostgroup = 'linux-atomia-agents,linux-all'}
+      'glusterfs': {
+        $hostgroup = 'linux-all'
+        class { $mailserver_class: }
+      }
+      'mysql':                { $hostgroup = 'linux-atomia-agents,linux-all'}
+      'phpmyadmin':           { $hostgroup = 'linux-atomia-agents,linux-all'}
+      'postgresql':           { $hostgroup = 'linux-atomia-agents,linux-all'}
+      'glusterfs': {
+        $hostgroup = 'linux-all'
+        class { $glusterfs_class: }
+      }
+      'glusterfs_replica': {
+        $hostgroup = 'linux-all'
+        class { $glusterfs_class: }
+      }
+      'internal_mailserver': {
+        $hostgroup = 'linux-all'
+        class { $internal_mailserver_class: }
+      }
+      'atomia_database': {
+        $hostgroup = 'linux-all'
+        class { $atomia_database_class: }
+      }
+      default: {
+        warning('Unsupported config')
+      }
 
     }
     if ! defined(Service['nagios-nrpe-server']) {
       service { 'nagios-nrpe-server':
-          ensure => running,
-          require => Package["nagios-nrpe-server"],
+        ensure  => running,
+        require => Package['nagios-nrpe-server'],
       }
     }
 
@@ -182,64 +188,64 @@ class atomia::nagios::client(
     $daggre_check_traffic_url = "http://${daggre_ip}:999/g?a=${daggre_token}&o=100000&latest=web_traffic_bytes"
     # Configuration files
     file { '/etc/nagios/nrpe.cfg':
-        owner   => 'root',
-        group   => 'root',
-        mode    => "0644",
-        content => template('atomia/nagios/nrpe.cfg.erb'),
-        require => Package["nagios-nrpe-server"],
-        notify  => Service["nagios-nrpe-server"]
-    }
-    
-
-    @@nagios_host { "${fqdn}-host" :
-        use                 => "generic-host",
-        host_name           => $fqdn,
-        alias			    => "${atomia_role_1} - ${fqdn}",
-        address             => $ip_address,
-        target              => "/usr/local/nagios/etc/servers/${hostname}_host.cfg",
-        hostgroups          => $hostgroup,
-        max_check_attempts  => '5'
-    }
- 
-
-	if ($atomia_role_1 == "daggre") {
-		@@nagios_service { "${fqdn}-daggre":
-			host_name				=> $fqdn,
-			service_description		=> "Daggre disk space parser",
-			check_command			=> "check_nrpe_1arg!check_daggre_ftp",
-			use						=> "generic-service",
-			target              	=> "/etc/nagios3/conf.d/${hostname}_services.cfg",
-		}
-
-        @@nagios_service { "${fqdn}-daggre-weblog":
-            host_name               => $fqdn,
-            service_description     => "Daggre weblog parser",
-            check_command           => "check_nrpe_1arg!check_daggre_weblog",
-            use                     => "generic-service",
-            target                  => "/etc/nagios3/conf.d/${hostname}_services.cfg",
-        }
-
-	}
-
-
-    if ($atomia_role == "domainreg") {
-
-        @@nagios_service { "${fqdn}-domainreg":
-            host_name               => $fqdn,
-            service_description     => "Domainreg API .com",
-            check_command           => "check_nrpe!check_domainreg!foo.com",
-            use                     => "generic-service",
-            target                  => "/etc/nagios3/conf.d/${hostname}_services.cfg",
-        }
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0644',
+      content => template('atomia/nagios/nrpe.cfg.erb'),
+      require => Package['nagios-nrpe-server'],
+      notify  => Service['nagios-nrpe-server']
     }
 
-	if !defined(File["/usr/lib/nagios/plugins/atomia"]){
-    	file { "/usr/lib/nagios/plugins/atomia":
-			source 				=> "puppet:///modules/atomia/nagios/plugins",
-			recurse				=> true,
-			require             => Package["nagios-nrpe-server"]
-		}
-	}
 
-	}
+    @@nagios_host { "${::fqdn}-host" :
+      use                => 'generic-host',
+      host_name          => $::fqdn,
+      alias              => "${::atomia_role_1} - ${::fqdn}",
+      address            => $ip_address,
+      target             => "/usr/local/nagios/etc/servers/${::hostname}_host.cfg",
+      hostgroups         => $hostgroup,
+      max_check_attempts => '5'
+    }
+
+
+    if ($::atomia_role_1 == 'daggre') {
+      @@nagios_service { "${::fqdn}-daggre":
+        host_name           => $::fqdn,
+        service_description => 'Daggre disk space parser',
+        check_command       => 'check_nrpe_1arg!check_daggre_ftp',
+        use                 => 'generic-service',
+        target              => "/etc/nagios3/conf.d/${::hostname}_services.cfg",
+      }
+
+      @@nagios_service { "${::fqdn}-daggre-weblog":
+        host_name           => $::fqdn,
+        service_description => 'Daggre weblog parser',
+        check_command       => 'check_nrpe_1arg!check_daggre_weblog',
+        use                 => 'generic-service',
+        target              => "/etc/nagios3/conf.d/${::hostname}_services.cfg",
+      }
+
+    }
+
+
+    if ($::atomia_role == 'domainreg') {
+
+      @@nagios_service { "${::fqdn}-domainreg":
+        host_name           => $::fqdn,
+        service_description => 'Domainreg API .com',
+        check_command       => 'check_nrpe!check_domainreg!foo.com',
+        use                 => 'generic-service',
+        target              => "/etc/nagios3/conf.d/${::hostname}_services.cfg",
+      }
+    }
+
+    if !defined(File['/usr/lib/nagios/plugins/atomia']){
+      file { '/usr/lib/nagios/plugins/atomia':
+        source  => 'puppet:///modules/atomia/nagios/plugins',
+        recurse => true,
+        require => Package['nagios-nrpe-server']
+      }
+    }
+
+  }
 }

--- a/manifests/nagios/client/active_directory.pp
+++ b/manifests/nagios/client/active_directory.pp
@@ -1,16 +1,16 @@
 class atomia::nagios::client::active_directory (
   $hostgroup,
 
-  ) {
+) {
 
-     @@nagios_host { "${fqdn}-host" :
-        use                 => "generic-host",
-        host_name           => $fqdn,
-        alias			          => "Active Directory - $fqdn",
-        address             => $ip_address,
-        target              => "/usr/local/nagios/etc/servers/${hostname}_host.cfg",
-        hostgroups          => $hostgroup,
-        max_check_attempts  => '5'
-      }    
+  @@nagios_host { "${::fqdn}-host" :
+    use                => 'generic-host',
+    host_name          => $::fqdn,
+    alias              => "Active Directory - ${::fqdn}",
+    address            => $::ip_address,
+    target             => "/usr/local/nagios/etc/servers/${::hostname}_host.cfg",
+    hostgroups         => $hostgroup,
+    max_check_attempts => '5'
+  }
 
 }

--- a/manifests/nagios/client/apache_agent.pp
+++ b/manifests/nagios/client/apache_agent.pp
@@ -1,37 +1,37 @@
 class atomia::nagios::client::apache_agent (
 
-  ) {
+) {
 
-  @@nagios_service { "${fqdn}-apache_agent-mountpoints":
-    host_name				       => $fqdn,
-    service_description	  => "NFS mounts",
-    check_command			    => "check_nrpe!check_all_mountpoints",
-    use						        => "generic-service",
-    target              	=> "/usr/local/nagios/etc/servers/${hostname}_service.cfg",
+  @@nagios_service { "${::fqdn}-apache_agent-mountpoints":
+    host_name           => $::fqdn,
+    service_description => 'NFS mounts',
+    check_command       => 'check_nrpe!check_all_mountpoints',
+    use                 => 'generic-service',
+    target              => "/usr/local/nagios/etc/servers/${::hostname}_service.cfg",
   }
 
-  @@nagios_service { "${fqdn}-apache_agent-process-count":
-    host_name				       => $fqdn,
-    service_description	  => "Total processes",
-    check_command			    => "check_nrpe!check_total_procs",
-    use						        => "generic-service",
-    target              	=> "/usr/local/nagios/etc/servers/${hostname}_service.cfg",
+  @@nagios_service { "${::fqdn}-apache_agent-process-count":
+    host_name           => $::fqdn,
+    service_description => 'Total processes',
+    check_command       => 'check_nrpe!check_total_procs',
+    use                 => 'generic-service',
+    target              => "/usr/local/nagios/etc/servers/${::hostname}_service.cfg",
   }
 
-  @@nagios_service { "${fqdn}-apache_agent-process-apache":
-    host_name				       => $fqdn,
-    service_description	  => "Apache processes",
-    check_command			    => "check_nrpe!check_apache_procs",
-    use						        => "generic-service",
-    target              	=> "/usr/local/nagios/etc/servers/${hostname}_service.cfg",
+  @@nagios_service { "${::fqdn}-apache_agent-process-apache":
+    host_name           => $::fqdn,
+    service_description => 'Apache processes',
+    check_command       => 'check_nrpe!check_apache_procs',
+    use                 => 'generic-service',
+    target              => "/usr/local/nagios/etc/servers/${::hostname}_service.cfg",
   }
 
-  @@nagios_service { "${fqdn}-apache_agent-process-php":
-    host_name				       => $fqdn,
-    service_description	  => "PHP processes",
-    check_command			    => "check_nrpe!check_php_procs",
-    use						        => "generic-service",
-    target              	=> "/usr/local/nagios/etc/servers/${hostname}_service.cfg",
+  @@nagios_service { "${::fqdn}-apache_agent-process-php":
+    host_name           => $::fqdn,
+    service_description => 'PHP processes',
+    check_command       => 'check_nrpe!check_php_procs',
+    use                 => 'generic-service',
+    target              => "/usr/local/nagios/etc/servers/${::hostname}_service.cfg",
   }
 
 }

--- a/manifests/nagios/client/atomia_database.pp
+++ b/manifests/nagios/client/atomia_database.pp
@@ -1,22 +1,22 @@
 class atomia::nagios::client::atomia_database (
 
-  ) {
+) {
 
-  @@nagios_service { "${fqdn}-domainreg-process-count":
-    host_name				       => $fqdn,
-    service_description	  => "Total processes",
-    check_command			    => "check_nrpe!check_total_procs",
-    use						        => "generic-service",
-    target              	=> "/usr/local/nagios/etc/servers/${hostname}_service.cfg",
-    owner                 => "nagios"
+  @@nagios_service { "${::fqdn}-domainreg-process-count":
+    host_name           => $::fqdn,
+    service_description => 'Total processes',
+    check_command       => 'check_nrpe!check_total_procs',
+    use                 => 'generic-service',
+    target              => "/usr/local/nagios/etc/servers/${::hostname}_service.cfg",
+    owner               => 'nagios'
   }
 
-  @@nagios_service { "${fqdn}-postgres-process-atomia-database":
-    host_name   => $fqdn,
-    service_description => "Postgres processes",
-    check_command   => "check_nrpe!check_postgres_proc",
-    use => "generic-service",
-    target  => "/usr/local/nagios/etc/servers/${hostname}_service.cfg",
+  @@nagios_service { "${::fqdn}-postgres-process-atomia-database":
+    host_name           => $::fqdn,
+    service_description => 'Postgres processes',
+    check_command       => 'check_nrpe!check_postgres_proc',
+    use                 => 'generic-service',
+    target              => "/usr/local/nagios/etc/servers/${::hostname}_service.cfg",
   }
 
 }

--- a/manifests/nagios/client/atomiadns_master.pp
+++ b/manifests/nagios/client/atomiadns_master.pp
@@ -1,26 +1,26 @@
 class atomia::nagios::client::atomiadns_master (
 
-  ) {
+) {
 
-  $atomiadns_password = generate("/etc/puppet/modules/atomia/files/lookup_variable.sh", "atomiadns", "agent_password")
-  $atomiadns_user  = generate("/etc/puppet/modules/atomia/files/lookup_variable.sh", "atomiadns", "agent_user")
+  $atomiadns_password = generate('/etc/puppet/modules/atomia/files/lookup_variable.sh', 'atomiadns', 'agent_password')
+  $atomiadns_user     = generate('/etc/puppet/modules/atomia/files/lookup_variable.sh', 'atomiadns', 'agent_user')
 
-  @@nagios_service { "${fqdn}-atomiadns_master-process-count":
-    host_name				       => $fqdn,
-    service_description	  => "Total processes",
-    check_command			    => "check_nrpe!check_total_procs",
-    use						        => "generic-service",
-    target              	=> "/usr/local/nagios/etc/servers/${hostname}_service.cfg",
-    owner                 => "nagios"
+  @@nagios_service { "${::fqdn}-atomiadns_master-process-count":
+    host_name           => $::fqdn,
+    service_description => 'Total processes',
+    check_command       => 'check_nrpe!check_total_procs',
+    use                 => 'generic-service',
+    target              => "/usr/local/nagios/etc/servers/${::hostname}_service.cfg",
+    owner               => 'nagios'
   }
 
-  @@nagios_service { "${fqdn}-atomiadns":
-      host_name               => $fqdn,
-      service_description     => "AtomiaDNS API",
-      check_command           => "check_nrpe_1arg!check_atomiadns!atomia-nagios-test.net!$atomiadns_user!$atomiadns_password",
-      use                     => "generic-service",
-      target                  => "/usr/local/nagios/etc/servers/${hostname}_service.cfg",
-      owner                 => "nagios"
+  @@nagios_service { "${::fqdn}-atomiadns":
+    host_name           => $::fqdn,
+    service_description => 'AtomiaDNS API',
+    check_command       => "check_nrpe_1arg!check_atomiadns!atomia-nagios-test.net!${atomiadns_user}!${atomiadns_password}",
+    use                 => 'generic-service',
+    target              => "/usr/local/nagios/etc/servers/${::hostname}_service.cfg",
+    owner               => 'nagios'
   }
 }
 

--- a/manifests/nagios/client/awstats.pp
+++ b/manifests/nagios/client/awstats.pp
@@ -1,37 +1,37 @@
 class atomia::nagios::client::awstats (
-    $account_used_for_checks = "100000"
-  ) {
+  $account_used_for_checks = '100000'
+) {
 
-  @@nagios_service { "${fqdn}-awstats-mountpoints":
-    host_name				       => $fqdn,
-    service_description	  => "NFS mounts",
-    check_command			    => "check_nrpe!check_all_mountpoints",
-    use						        => "generic-service",
-    target              	=> "/usr/local/nagios/etc/servers/${hostname}_service.cfg",
+  @@nagios_service { "${::fqdn}-awstats-mountpoints":
+    host_name           => $::fqdn,
+    service_description => 'NFS mounts',
+    check_command       => 'check_nrpe!check_all_mountpoints',
+    use                 => 'generic-service',
+    target              => "/usr/local/nagios/etc/servers/${::hostname}_service.cfg",
   }
 
-  @@nagios_service { "${fqdn}-awstats-process-count":
-    host_name				       => $fqdn,
-    service_description	  => "Total processes",
-    check_command			    => "check_nrpe!check_total_procs",
-    use						        => "generic-service",
-    target              	=> "/usr/local/nagios/etc/servers/${hostname}_service.cfg",
+  @@nagios_service { "${::fqdn}-awstats-process-count":
+    host_name           => $::fqdn,
+    service_description => 'Total processes',
+    check_command       => 'check_nrpe!check_total_procs',
+    use                 => 'generic-service',
+    target              => "/usr/local/nagios/etc/servers/${::hostname}_service.cfg",
   }
-  
-  @@nagios_service { "${fqdn}-apace-process-awstats":
-    host_name				       => $fqdn,
-    service_description	  => "Apache processes",
-    check_command			    => "check_nrpe!check_apache_procs",
-    use						        => "generic-service",
-    target              	=> "/usr/local/nagios/etc/servers/${hostname}_service.cfg",
-  }  
 
-  @@nagios_service { "${fqdn}-awstats-process-awstats":
-    host_name				       => $fqdn,
-    service_description	  => "Awstats agent processes",
-    check_command			    => "check_nrpe!check_awstats_procs",
-    use						        => "generic-service",
-    target              	=> "/usr/local/nagios/etc/servers/${hostname}_service.cfg",
-  }  
+  @@nagios_service { "${::fqdn}-apace-process-awstats":
+    host_name           => $::fqdn,
+    service_description => 'Apache processes',
+    check_command       => 'check_nrpe!check_apache_procs',
+    use                 => 'generic-service',
+    target              => "/usr/local/nagios/etc/servers/${::hostname}_service.cfg",
+  }
+
+  @@nagios_service { "${::fqdn}-awstats-process-awstats":
+    host_name           => $::fqdn,
+    service_description => 'Awstats agent processes',
+    check_command       => 'check_nrpe!check_awstats_procs',
+    use                 => 'generic-service',
+    target              => "/usr/local/nagios/etc/servers/${::hostname}_service.cfg",
+  }
 
 }

--- a/manifests/nagios/client/cronagent.pp
+++ b/manifests/nagios/client/cronagent.pp
@@ -1,24 +1,23 @@
 class atomia::nagios::client::cronagent (
 
-  ) {
+) {
 
-  @@nagios_service { "${fqdn}-cronagent-process-count":
-    host_name				       => $fqdn,
-    service_description	  => "Total processes",
-    check_command			    => "check_nrpe!check_total_procs",
-    use						        => "generic-service",
-    target              	=> "/usr/local/nagios/etc/servers/${hostname}_service.cfg",
-    owner                 => "nagios"
+  @@nagios_service { "${::fqdn}-cronagent-process-count":
+    host_name           => $::fqdn,
+    service_description => 'Total processes',
+    check_command       => 'check_nrpe!check_total_procs',
+    use                 => 'generic-service',
+    target              => "/usr/local/nagios/etc/servers/${::hostname}_service.cfg",
+    owner               => 'nagios'
   }
 
 
-  @@nagios_service { "${fqdn}-cronagent-process":
-    host_name   => $fqdn,
-    service_description => "Cronagent processes",
-    check_command   => "check_nrpe!check_cronagent_proc",
-    use => "generic-service",
-    target  => "/usr/local/nagios/etc/servers/${hostname}_service.cfg",
+  @@nagios_service { "${::fqdn}-cronagent-process":
+    host_name           => $::fqdn,
+    service_description => 'Cronagent processes',
+    check_command       => 'check_nrpe!check_cronagent_proc',
+    use                 => 'generic-service',
+    target              => "/usr/local/nagios/etc/servers/${::hostname}_service.cfg",
   }
-
 
 }

--- a/manifests/nagios/client/daggre.pp
+++ b/manifests/nagios/client/daggre.pp
@@ -1,40 +1,38 @@
 class atomia::nagios::client::daggre (
 
-  ) {
+) {
 
-  @@nagios_service { "${fqdn}-daggre-process-count":
-    host_name				       => $fqdn,
-    service_description	  => "Total processes",
-    check_command			    => "check_nrpe!check_total_procs",
-    use						        => "generic-service",
-    target              	=> "/usr/local/nagios/etc/servers/${hostname}_service.cfg",
-    owner                 => "nagios"
+  @@nagios_service { "${::fqdn}-daggre-process-count":
+    host_name           => $::fqdn,
+    service_description => 'Total processes',
+    check_command       => 'check_nrpe!check_total_procs',
+    use                 => 'generic-service',
+    target              => "/usr/local/nagios/etc/servers/${::hostname}_service.cfg",
+    owner               => 'nagios'
   }
 
-
-  @@nagios_service { "${fqdn}-daggre-process":
-    host_name   => $fqdn,
-    service_description => "Daggre processes",
-    check_command   => "check_nrpe!check_daggre_proc",
-    use => "generic-service",
-    target  => "/usr/local/nagios/etc/servers/${hostname}_service.cfg",
+  @@nagios_service { "${::fqdn}-daggre-process":
+    host_name           => $::fqdn,
+    service_description => 'Daggre processes',
+    check_command       => 'check_nrpe!check_daggre_proc',
+    use                 => 'generic-service',
+    target              => "/usr/local/nagios/etc/servers/${::hostname}_service.cfg",
   }
 
-
-  @@nagios_service { "${fqdn}-daggre-check-ftp":
-    host_name   => $fqdn,
-    service_description => "Daggre FTP",
-    check_command   => "check_nrpe!check_daggre_ftp",
-    use => "generic-service",
-    target  => "/usr/local/nagios/etc/servers/${hostname}_service.cfg",
+  @@nagios_service { "${::fqdn}-daggre-check-ftp":
+    host_name           => $::fqdn,
+    service_description => 'Daggre FTP',
+    check_command       => 'check_nrpe!check_daggre_ftp',
+    use                 => 'generic-service',
+    target              => "/usr/local/nagios/etc/servers/${::hostname}_service.cfg",
   }
 
-  @@nagios_service { "${fqdn}-daggre-check-weblog":
-    host_name   => $fqdn,
-    service_description => "Daggre Weblog",
-    check_command   => "check_nrpe!check_daggre_weblog",
-    use => "generic-service",
-    target  => "/usr/local/nagios/etc/servers/${hostname}_service.cfg",
+  @@nagios_service { "${::fqdn}-daggre-check-weblog":
+    host_name           => $::fqdn,
+    service_description => 'Daggre Weblog',
+    check_command       => 'check_nrpe!check_daggre_weblog',
+    use                 => 'generic-service',
+    target              => "/usr/local/nagios/etc/servers/${::hostname}_service.cfg",
   }
 
 }

--- a/manifests/nagios/client/domainreg.pp
+++ b/manifests/nagios/client/domainreg.pp
@@ -1,24 +1,23 @@
 class atomia::nagios::client::domainreg (
 
-  ) {
+) {
 
-  @@nagios_service { "${fqdn}-domainreg-process-count":
-    host_name				       => $fqdn,
-    service_description	  => "Total processes",
-    check_command			    => "check_nrpe!check_total_procs",
-    use						        => "generic-service",
-    target              	=> "/usr/local/nagios/etc/servers/${hostname}_service.cfg",
-    owner                 => "nagios"
+  @@nagios_service { "${::fqdn}-domainreg-process-count":
+    host_name           => $::fqdn,
+    service_description => 'Total processes',
+    check_command       => 'check_nrpe!check_total_procs',
+    use                 => 'generic-service',
+    target              => "/usr/local/nagios/etc/servers/${::hostname}_service.cfg",
+    owner               => 'nagios'
   }
 
-
-  @@nagios_service { "${fqdn}-domainreg":
-      host_name               => $fqdn,
-      service_description     => "Domainreg API .com",
-      check_command           => "check_nrpe_1arg!check_domainreg!atomia-test-domain.com",
-      use                     => "generic-service",
-      target              	=> "/usr/local/nagios/etc/servers/${hostname}_service.cfg",
-      owner                 => "nagios"
+  @@nagios_service { "${::fqdn}-domainreg":
+    host_name           => $::fqdn,
+    service_description => 'Domainreg API .com',
+    check_command       => 'check_nrpe_1arg!check_domainreg!atomia-test-domain.com',
+    use                 => 'generic-service',
+    target              => "/usr/local/nagios/etc/servers/${::hostname}_service.cfg",
+    owner               => 'nagios'
   }
 
 }

--- a/manifests/nagios/client/fsagent.pp
+++ b/manifests/nagios/client/fsagent.pp
@@ -1,32 +1,33 @@
 class atomia::nagios::client::fsagent (
-    $account_used_for_checks = "100000"
-  ) {
+  $account_used_for_checks = '100000'
+) {
 
-  $fsagent_ip = generate("/etc/puppet/modules/atomia/files/lookup_variable.sh", "fsagent", "fsagent_ip")
-  $fsagent_url = "http://${hiera('atomia::fsagent::fsagent_ip','')}:10201"
-  $fsagent_username = hiera('atomia::fsagent::username','')
-  $fsagent_password = hiera('atomia::fsagent::password','')
-  @@nagios_service { "${fqdn}-fsagent-mountpoints":
-    host_name				       => $fqdn,
-    service_description	  => "NFS mounts",
-    check_command			    => "check_nrpe!check_all_mountpoints",
-    use						        => "generic-service",
-    target              	=> "/usr/local/nagios/etc/servers/${hostname}_service.cfg",
+  $fsagent_ip        = generate('/etc/puppet/modules/atomia/files/lookup_variable.sh', 'fsagent', 'fsagent_ip')
+  $fsagent_url_hiera = hiera('atomia::fsagent::fsagent_ip','')
+  $fsagent_url       = "http://${fsagent_url_hiera}:10201"
+  $fsagent_username  = hiera('atomia::fsagent::username','')
+  $fsagent_password  = hiera('atomia::fsagent::password','')
+  @@nagios_service { "${::fqdn}-fsagent-mountpoints":
+    host_name           => $::fqdn,
+    service_description => 'NFS mounts',
+    check_command       => 'check_nrpe!check_all_mountpoints',
+    use                 => 'generic-service',
+    target              => "/usr/local/nagios/etc/servers/${::hostname}_service.cfg",
   }
 
-  @@nagios_service { "${fqdn}-fsagent-process-count":
-    host_name				       => $fqdn,
-    service_description	  => "Total processes",
-    check_command			    => "check_nrpe!check_total_procs",
-    use						        => "generic-service",
-    target              	=> "/usr/local/nagios/etc/servers/${hostname}_service.cfg",
+  @@nagios_service { "${::fqdn}-fsagent-process-count":
+    host_name           => $::fqdn,
+    service_description => 'Total processes',
+    check_command       => 'check_nrpe!check_total_procs',
+    use                 => 'generic-service',
+    target              => "/usr/local/nagios/etc/servers/${::hostname}_service.cfg",
   }
 
-  @@nagios_service { "${fqdn}-fsagent-api-check":
-    host_name				       => $fqdn,
-    service_description	  => "Fsagent API",
-    check_command			    => "check_fsagent!${account_used_for_checks}!${fsagent_url}!${fsagent_username}!${fsagent_password}",
-    use						        => "generic-service",
-    target              	=> "/usr/local/nagios/etc/servers/${hostname}_service.cfg",
+  @@nagios_service { "${::fqdn}-fsagent-api-check":
+    host_name           => $::fqdn,
+    service_description => 'Fsagent API',
+    check_command       => "check_fsagent!${account_used_for_checks}!${fsagent_url}!${fsagent_username}!${fsagent_password}",
+    use                 => 'generic-service',
+    target              => "/usr/local/nagios/etc/servers/${::hostname}_service.cfg",
   }
 }

--- a/manifests/nagios/client/glusterfs.pp
+++ b/manifests/nagios/client/glusterfs.pp
@@ -1,44 +1,43 @@
 class atomia::nagios::client::glusterfs (
   $num_bricks = 2,
-  ) {
+) {
 
-  @@nagios_service { "${fqdn}-glusterfs-process-count":
-    host_name				    => $fqdn,
-    service_description	  		=> "Total processes",
-    check_command			    => "check_nrpe!check_total_procs",
-    use						    => "generic-service",
-    target              		=> "/usr/local/nagios/etc/servers/${hostname}_service.cfg",
-    owner                	 	=> "nagios"
+  @@nagios_service { "${::fqdn}-glusterfs-process-count":
+    host_name           => $::fqdn,
+    service_description => 'Total processes',
+    check_command       => 'check_nrpe!check_total_procs',
+    use                 => 'generic-service',
+    target              => "/usr/local/nagios/etc/servers/${::hostname}_service.cfg",
+    owner               => 'nagios'
   }
 
-
-  @@nagios_service { "${fqdn}-glusterfs-health-web-volume":
-      host_name               => $fqdn,
-      service_description     => "GlusterFS health web_volume",
-      check_command           => "check_nrpe_1arg!check_glusterfs!web_volume!${num_bricks}",
-      use                     => "generic-service",
-      target              	  => "/usr/local/nagios/etc/servers/${hostname}_service.cfg",
-      owner                   => "nagios"
+  @@nagios_service { "${::fqdn}-glusterfs-health-web-volume":
+    host_name           => $::fqdn,
+    service_description => 'GlusterFS health web_volume',
+    check_command       => "check_nrpe_1arg!check_glusterfs!web_volume!${num_bricks}",
+    use                 => 'generic-service',
+    target              => "/usr/local/nagios/etc/servers/${::hostname}_service.cfg",
+    owner               => 'nagios'
   }
-  
-  @@nagios_service { "${fqdn}-glusterfs-health-config-volume":
-      host_name               => $fqdn,
-      service_description     => "GlusterFS health config_volume",
-      check_command           => "check_nrpe_1arg!check_glusterfs!config_volume!${num_bricks}",
-      use                     => "generic-service",
-      target              	  => "/usr/local/nagios/etc/servers/${hostname}_service.cfg",
-      owner                   => "nagios"
-  }  
 
-  @@nagios_service { "${fqdn}-glusterfs-health-mail-volume":
-      host_name               => $fqdn,
-      service_description     => "GlusterFS health mail_volume",
-      check_command           => "check_nrpe_1arg!check_glusterfs!mail_volume!${num_bricks}",
-      use                     => "generic-service",
-      target              	  => "/usr/local/nagios/etc/servers/${hostname}_service.cfg",
-      owner                   => "nagios"
-  }  
-  
+  @@nagios_service { "${::fqdn}-glusterfs-health-config-volume":
+    host_name           => $::fqdn,
+    service_description => 'GlusterFS health config_volume',
+    check_command       => "check_nrpe_1arg!check_glusterfs!config_volume!${num_bricks}",
+    use                 => 'generic-service',
+    target              => "/usr/local/nagios/etc/servers/${::hostname}_service.cfg",
+    owner               => 'nagios'
+  }
+
+  @@nagios_service { "${::fqdn}-glusterfs-health-mail-volume":
+    host_name           => $::fqdn,
+    service_description => 'GlusterFS health mail_volume',
+    check_command       => "check_nrpe_1arg!check_glusterfs!mail_volume!${num_bricks}",
+    use                 => 'generic-service',
+    target              => "/usr/local/nagios/etc/servers/${::hostname}_service.cfg",
+    owner               => 'nagios'
+  }
+
   file_line { 'sudo_rule':
     path => '/etc/sudoers',
     line => 'nagios ALL=NOPASSWD:/usr/sbin/gluster volume status*,/usr/sbin/gluster volume heal*',

--- a/manifests/nagios/client/iis.pp
+++ b/manifests/nagios/client/iis.pp
@@ -1,24 +1,24 @@
 class atomia::nagios::client::iis (
   $hostgroup,
 
-  ) {
+) {
 
-     @@nagios_host { "${fqdn}-host" :
-        use                 => "generic-host",
-        host_name           => $fqdn,
-        alias			    => "IIS - $fqdn",
-        address             => $ip_address,
-        target              => "/usr/local/nagios/etc/servers/${hostname}_host.cfg",
-        hostgroups          => $hostgroup,
-        max_check_attempts  => '5'
-      }    
+  @@nagios_host { "${::fqdn}-host" :
+    use                => 'generic-host',
+    host_name          => $::fqdn,
+    alias              => "IIS - ${::fqdn}",
+    address            => $::ip_address,
+    target             => "/usr/local/nagios/etc/servers/${::hostname}_host.cfg",
+    hostgroups         => $hostgroup,
+    max_check_attempts => '5'
+  }
 
-    @@nagios_service { "${fqdn}-iis-service-status":
-        host_name               => $fqdn,
-        service_description     => "IIS service status",
-        check_command           => "check_nt_service!W3SVC",
-        use                     => "generic-service",
-        target              	=> "/usr/local/nagios/etc/servers/${hostname}_service.cfg",
-        owner                 => "nagios"
-    }         
+  @@nagios_service { "${::fqdn}-iis-service-status":
+    host_name           => $::fqdn,
+    service_description => 'IIS service status',
+    check_command       => 'check_nt_service!W3SVC',
+    use                 => 'generic-service',
+    target              => "/usr/local/nagios/etc/servers/${::hostname}_service.cfg",
+    owner               => 'nagios'
+  }
 }

--- a/manifests/nagios/client/internal_apps.pp
+++ b/manifests/nagios/client/internal_apps.pp
@@ -1,69 +1,69 @@
 class atomia::nagios::client::internal_apps (
   $hostgroup,
 
-  ) {
+) {
 
-     @@nagios_host { "${fqdn}-host" :
-        use                 => "generic-host",
-        host_name           => $fqdn,
-        alias			    => "Internal Apps - $fqdn",
-        address             => $ip_address,
-        target              => "/usr/local/nagios/etc/servers/${hostname}_host.cfg",
-        hostgroups          => $hostgroup,
-        max_check_attempts  => '5'
-      }    
-    
-  @@nagios_service { "${fqdn}-iis-service-status":
-      host_name               => $fqdn,
-      service_description     => "IIS service status",
-      check_command           => "check_nt_service!W3SVC",
-      use                     => "generic-service",
-      target              	=> "/usr/local/nagios/etc/servers/${hostname}_service.cfg",
-      owner                 => "nagios"
-   }    
-
-  @@nagios_service { "${fqdn}-as-cleanup-status":
-      host_name               => $fqdn,
-      service_description     => "Automationserver cleanup service status",
-      check_command           => "check_nt_service!'Atomia Automation Server Clean Up Service'",
-      use                     => "generic-service",
-      target              	  => "/usr/local/nagios/etc/servers/${hostname}_service.cfg",
-      owner                   => "nagios"
-  }    
-
-  @@nagios_service { "${fqdn}-as-updater-status":
-      host_name               => $fqdn,
-      service_description     => "Automationserver periodic updater service status",
-      check_command           => "check_nt_service!'Atomia Automation Server Periodic Updater'",
-      use                     => "generic-service",
-      target              	  => "/usr/local/nagios/etc/servers/${hostname}_service.cfg",
-      owner                   => "nagios"
-  }   
-  @@nagios_service { "${fqdn}-as-engine-status":
-      host_name               => $fqdn,
-      service_description     => "Automationserver provisioning engine service status",
-      check_command           => "check_nt_service!'Atomia Automation Server Provisioning Engine'",
-      use                     => "generic-service",
-      target              	  => "/usr/local/nagios/etc/servers/${hostname}_service.cfg",
-      owner                   => "nagios"
+  @@nagios_host { "${::fqdn}-host" :
+    use                => 'generic-host',
+    host_name          => $::fqdn,
+    alias              => "Internal Apps - ${::fqdn}",
+    address            => $::ip_address,
+    target             => "/usr/local/nagios/etc/servers/${::hostname}_host.cfg",
+    hostgroups         => $hostgroup,
+    max_check_attempts => '5'
   }
-  
-  @@nagios_service { "${fqdn}-mail-dispatcher-status":
-      host_name               => $fqdn,
-      service_description     => "Atomia mail dispatcher service status",
-      check_command           => "check_nt_service!'Atomia Mail Dispatcher'",
-      use                     => "generic-service",
-      target              	  => "/usr/local/nagios/etc/servers/${hostname}_service.cfg",
-      owner                   => "nagios"
+
+  @@nagios_service { "${::fqdn}-iis-service-status":
+    host_name           => $::fqdn,
+    service_description => 'IIS service status',
+    check_command       => 'check_nt_service!W3SVC',
+    use                 => 'generic-service',
+    target              => "/usr/local/nagios/etc/servers/${::hostname}_service.cfg",
+    owner               => 'nagios'
   }
-  
-  @@nagios_service { "${fqdn}-ticker-service-status":
-      host_name               => $fqdn,
-      service_description     => "Atomia ticker service status",
-      check_command           => "check_nt_service!'Atomia Ticker Service'",
-      use                     => "generic-service",
-      target              	  => "/usr/local/nagios/etc/servers/${hostname}_service.cfg",
-      owner                   => "nagios"
-  }       
-         
+
+  @@nagios_service { "${::fqdn}-as-cleanup-status":
+    host_name           => $::fqdn,
+    service_description => 'Automationserver cleanup service status',
+    check_command       => "check_nt_service!'Atomia Automation Server Clean Up Service'",
+    use                 => 'generic-service',
+    target              => "/usr/local/nagios/etc/servers/${::hostname}_service.cfg",
+    owner               => 'nagios'
+  }
+
+  @@nagios_service { "${::fqdn}-as-updater-status":
+    host_name           => $::fqdn,
+    service_description => 'Automationserver periodic updater service status',
+    check_command       => "check_nt_service!'Atomia Automation Server Periodic Updater'",
+    use                 => 'generic-service',
+    target              => "/usr/local/nagios/etc/servers/${::hostname}_service.cfg",
+    owner               => 'nagios'
+  }
+  @@nagios_service { "${::fqdn}-as-engine-status":
+    host_name           => $::fqdn,
+    service_description => 'Automationserver provisioning engine service status',
+    check_command       => "check_nt_service!'Atomia Automation Server Provisioning Engine'",
+    use                 => 'generic-service',
+    target              => "/usr/local/nagios/etc/servers/${::hostname}_service.cfg",
+    owner               => 'nagios'
+  }
+
+  @@nagios_service { "${::fqdn}-mail-dispatcher-status":
+    host_name           => $::fqdn,
+    service_description => 'Atomia mail dispatcher service status',
+    check_command       => "check_nt_service!'Atomia Mail Dispatcher'",
+    use                 => 'generic-service',
+    target              => "/usr/local/nagios/etc/servers/${::hostname}_service.cfg",
+    owner               => 'nagios'
+  }
+
+  @@nagios_service { "${::fqdn}-ticker-service-status":
+    host_name           => $::fqdn,
+    service_description => 'Atomia ticker service status',
+    check_command       => "check_nt_service!'Atomia Ticker Service'",
+    use                 => 'generic-service',
+    target              => "/usr/local/nagios/etc/servers/${::hostname}_service.cfg",
+    owner               => 'nagios'
+  }
+
 }

--- a/manifests/nagios/client/internal_mailserver.pp
+++ b/manifests/nagios/client/internal_mailserver.pp
@@ -1,16 +1,14 @@
 class atomia::nagios::client::internal_mailserver (
 
-  ) {
+) {
 
-  @@nagios_service { "${fqdn}-internalmailserver-process-count":
-    host_name			=> $fqdn,
-    service_description	=> "Total processes",
-    check_command		=> "check_nrpe!check_total_procs",
-    use					=> "generic-service",
-    target				=> "/usr/local/nagios/etc/servers/${hostname}_service.cfg",
-    owner				=> "nagios"
+  @@nagios_service { "${::fqdn}-internalmailserver-process-count":
+    host_name           => $::fqdn,
+    service_description => 'Total processes',
+    check_command       => 'check_nrpe!check_total_procs',
+    use                 => 'generic-service',
+    target              => "/usr/local/nagios/etc/servers/${::hostname}_service.cfg",
+    owner               => 'nagios'
   }
-
-
 
 }

--- a/manifests/nagios/client/internaldns.pp
+++ b/manifests/nagios/client/internaldns.pp
@@ -1,23 +1,22 @@
 class atomia::nagios::client::internaldns (
 
-  ) {
+) {
 
-  @@nagios_service { "${fqdn}-internaldns-process-count":
-    host_name   => $fqdn,
-    service_description => "Total processes",
-    check_command   => "check_nrpe!check_total_procs",
-    use => "generic-service",
-    target  => "/usr/local/nagios/etc/servers/${hostname}_service.cfg",
-    owner   => "nagios"
+  @@nagios_service { "${::fqdn}-internaldns-process-count":
+    host_name           => $::fqdn,
+    service_description => 'Total processes',
+    check_command       => 'check_nrpe!check_total_procs',
+    use                 => 'generic-service',
+    target              => "/usr/local/nagios/etc/servers/${::hostname}_service.cfg",
+    owner               => 'nagios'
   }
 
-  @@nagios_service { "${fqdn}-bind-process-internaldns":
-    host_name   => $fqdn,
-    service_description => "Bind processes",
-    check_command   => "check_nrpe!check_bind_proc",
-    use => "generic-service",
-    target  => "/usr/local/nagios/etc/servers/${hostname}_service.cfg",
+  @@nagios_service { "${::fqdn}-bind-process-internaldns":
+    host_name           => $::fqdn,
+    service_description => 'Bind processes',
+    check_command       => 'check_nrpe!check_bind_proc',
+    use                 => 'generic-service',
+    target              => "/usr/local/nagios/etc/servers/${::hostname}_service.cfg",
   }
-
 
 }

--- a/manifests/nagios/client/mailserver.pp
+++ b/manifests/nagios/client/mailserver.pp
@@ -1,16 +1,14 @@
 class atomia::nagios::client::mailserver (
 
-  ) {
+) {
 
-  @@nagios_service { "${fqdn}-mailserver-process-count":
-    host_name			=> $fqdn,
-    service_description	=> "Total processes",
-    check_command		=> "check_nrpe!check_total_procs",
-    use					=> "generic-service",
-    target				=> "/usr/local/nagios/etc/servers/${hostname}_service.cfg",
-    owner				=> "nagios"
+  @@nagios_service { "${::fqdn}-mailserver-process-count":
+    host_name           => $::fqdn,
+    service_description => 'Total processes',
+    check_command       => 'check_nrpe!check_total_procs',
+    use                 => 'generic-service',
+    target              => "/usr/local/nagios/etc/servers/${::hostname}_service.cfg",
+    owner               => 'nagios'
   }
-
-
 
 }

--- a/manifests/nagios/client/nameserver.pp
+++ b/manifests/nagios/client/nameserver.pp
@@ -1,29 +1,29 @@
 class atomia::nagios::client::nameserver (
 
-  ) {
+) {
 
-  @@nagios_service { "${fqdn}-nameserver-process-count":
-    host_name				       => $fqdn,
-    service_description	  => "Total processes",
-    check_command			    => "check_nrpe!check_total_procs",
-    use						        => "generic-service",
-    target              	=> "/usr/local/nagios/etc/servers/${hostname}_service.cfg",
+  @@nagios_service { "${::fqdn}-nameserver-process-count":
+    host_name           => $::fqdn,
+    service_description => 'Total processes',
+    check_command       => 'check_nrpe!check_total_procs',
+    use                 => 'generic-service',
+    target              => "/usr/local/nagios/etc/servers/${::hostname}_service.cfg",
   }
 
-  @@nagios_service { "${fqdn}-nameserver-process-powerdnssync":
-    host_name				       => $fqdn,
-    service_description	  => "Powerdnssync",
-    check_command			    => "check_nrpe!check_powerdnssync_procs",
-    use						        => "generic-service",
-    target              	=> "/usr/local/nagios/etc/servers/${hostname}_service.cfg",
+  @@nagios_service { "${::fqdn}-nameserver-process-powerdnssync":
+    host_name           => $::fqdn,
+    service_description => 'Powerdnssync',
+    check_command       => 'check_nrpe!check_powerdnssync_procs',
+    use                 => 'generic-service',
+    target              => "/usr/local/nagios/etc/servers/${::hostname}_service.cfg",
   }
 
-  @@nagios_service { "${fqdn}-nameserver-dig":
-    host_name				       => $fqdn,
-    service_description	  => "Dig",
-    check_command			    => "check_dig!${hostname}!atomia-nagios-test.net!ANY",
-    use						        => "generic-service",
-    target              	=> "/usr/local/nagios/etc/servers/${hostname}_service.cfg",
+  @@nagios_service { "${::fqdn}-nameserver-dig":
+    host_name           => $::fqdn,
+    service_description => 'Dig',
+    check_command       => "check_dig!${::hostname}!atomia-nagios-test.net!ANY",
+    use                 => 'generic-service',
+    target              => "/usr/local/nagios/etc/servers/${::hostname}_service.cfg",
   }
 
 }

--- a/manifests/nagios/client/public_apps.pp
+++ b/manifests/nagios/client/public_apps.pp
@@ -1,25 +1,25 @@
 class atomia::nagios::client::public_apps (
   $hostgroup,
 
-  ) {
+) {
 
-     @@nagios_host { "${fqdn}-host" :
-        use                 => "generic-host",
-        host_name           => $fqdn,
-        alias			    => "Public Apps - $fqdn",
-        address             => $ip_address,
-        target              => "/usr/local/nagios/etc/servers/${hostname}_host.cfg",
-        hostgroups          => $hostgroup,
-        max_check_attempts  => '5'
-      }  
-      
-  @@nagios_service { "${fqdn}-iis-service-status":
-      host_name               => $fqdn,
-      service_description     => "IIS service status",
-      check_command           => "check_nt_service!W3SVC",
-      use                     => "generic-service",
-      target              	=> "/usr/local/nagios/etc/servers/${hostname}_service.cfg",
-      owner                 => "nagios"
-  }            
+  @@nagios_host { "${::fqdn}-host" :
+    use                => 'generic-host',
+    host_name          => $::fqdn,
+    alias              => "Public Apps - ${::fqdn}",
+    address            => $::ip_address,
+    target             => "/usr/local/nagios/etc/servers/${::hostname}_host.cfg",
+    hostgroups         => $hostgroup,
+    max_check_attempts => '5'
+  }
+
+  @@nagios_service { "${::fqdn}-iis-service-status":
+    host_name           => $::fqdn,
+    service_description => 'IIS service status',
+    check_command       => 'check_nt_service!W3SVC',
+    use                 => 'generic-service',
+    target              => "/usr/local/nagios/etc/servers/${::hostname}_service.cfg",
+    owner               => 'nagios'
+  }
 
 }

--- a/manifests/nagios/client/pureftpd.pp
+++ b/manifests/nagios/client/pureftpd.pp
@@ -1,29 +1,28 @@
 class atomia::nagios::client::pureftpd (
-  ) {
+) {
 
-  @@nagios_service { "${fqdn}-pureftpd-mountpoints":
-    host_name				       => $fqdn,
-    service_description	  => "NFS mounts",
-    check_command			    => "check_nrpe!check_all_mountpoints",
-    use						        => "generic-service",
-    target              	=> "/usr/local/nagios/etc/servers/${hostname}_service.cfg",
+  @@nagios_service { "${::fqdn}-pureftpd-mountpoints":
+    host_name           => $::fqdn,
+    service_description => 'NFS mounts',
+    check_command       => 'check_nrpe!check_all_mountpoints',
+    use                 => 'generic-service',
+    target              => "/usr/local/nagios/etc/servers/${::hostname}_service.cfg",
   }
 
-  @@nagios_service { "${fqdn}-pureftpd-process-count":
-    host_name				       => $fqdn,
-    service_description	  => "Total processes",
-    check_command			    => "check_nrpe!check_total_procs",
-    use						        => "generic-service",
-    target              	=> "/usr/local/nagios/etc/servers/${hostname}_service.cfg",
-  }
-  
-    @@nagios_service { "${fqdn}-pureftpd-process":
-    host_name   => $fqdn,
-    service_description => "Pureftpd processes",
-    check_command   => "check_nrpe!check_pureftpd_proc",
-    use => "generic-service",
-    target  => "/usr/local/nagios/etc/servers/${hostname}_service.cfg",
+  @@nagios_service { "${::fqdn}-pureftpd-process-count":
+    host_name           => $::fqdn,
+    service_description => 'Total processes',
+    check_command       => 'check_nrpe!check_total_procs',
+    use                 => 'generic-service',
+    target              => "/usr/local/nagios/etc/servers/${::hostname}_service.cfg",
   }
 
+  @@nagios_service { "${::fqdn}-pureftpd-process":
+    host_name           => $::fqdn,
+    service_description => 'Pureftpd processes',
+    check_command       => 'check_nrpe!check_pureftpd_proc',
+    use                 => 'generic-service',
+    target              => "/usr/local/nagios/etc/servers/${::hostname}_service.cfg",
+  }
 
 }

--- a/manifests/nfsmount.pp
+++ b/manifests/nfsmount.pp
@@ -1,102 +1,102 @@
 define atomia::nfsmount(
-		$use_nfs3,
-		$mount_point,
-		$nfs_location,
-		$nfs_type = hiera('atomia::nfsmount::nfs_type', 'nfs'),
-		$nfs_options = hiera('atomia::nfsmount::nfs_options', 'rw,noatime'),
-		$ad_domain = "hiera('atomia::adjoin::domain_name', ''),"
+  $use_nfs3,
+  $mount_point,
+  $nfs_location,
+  $nfs_type      = hiera('atomia::nfsmount::nfs_type', 'nfs'),
+  $nfs_options   = hiera('atomia::nfsmount::nfs_options', 'rw,noatime'),
+  $ad_domain     = hiera('atomia::adjoin::domain_name', ''),
 ) {
 
 
-    if $nfs_type == "nfs" 
-    {
-        if $use_nfs3 {
-            $fs_type = "nfs"
-        } else {
-            $fs_type = "nfs4"
-        }
+  if $nfs_type == 'nfs'
+  {
+    if $use_nfs3 {
+      $fs_type = 'nfs'
+    } else {
+      $fs_type = 'nfs4'
     }
-    else
-    {
-        $fs_type = $nfs_type
+  }
+  else
+  {
+    $fs_type = $nfs_type
+  }
+
+  if !defined(File['/storage']) {
+    file { '/storage':
+      ensure => directory,
+    }
+  }
+
+  if !defined(File[$mount_point]) {
+    file { $mount_point:
+      ensure  => directory,
+      require => File['/storage'],
+      mode    => '0711',
+    }
+  }
+
+  if $::operatingsystem != 'CloudLinux' {
+    if !defined(Package['nfs-common']) {
+      package { 'nfs-common': ensure => present }
     }
 
-    if !defined(File["/storage"]) {
-        file { "/storage":
-            ensure => directory,
-        }
+    mount { $mount_point:
+      ensure   => mounted,
+      device   => $nfs_location,
+      fstype   => $fs_type,
+      remounts => false,
+      options  => $nfs_options,
+      require  => [File[$mount_point], Package['nfs-common']],
     }
 
-    if !defined(File[$mount_point]) {
-        file { $mount_point:
-            ensure => directory,
-            require => File["/storage"],
-            mode    => "711",
+    if $::operatingsystem != 'Debian' {
+      if !defined(Service['idmapd']){
+        service {'idmapd' :
+          ensure    => running,
+          subscribe => File['/etc/idmapd.conf'],
+          require   => [Package['nfs-common']],
         }
-    }
-    
-    if $operatingsystem != 'CloudLinux' {
-        if !defined(Package['nfs-common']) {
-            package { nfs-common: ensure => present }
-        }
-        
-        mount { $mount_point:
-            device => $nfs_location,
-            fstype => $fs_type,
-            remounts => false,
-            options => $nfs_options,
-            ensure => mounted,
-            require => [File[$mount_point], Package['nfs-common']],
-        }
-
-        if $operatingsystem != "Debian" {
-            if !defined(Service["idmapd"]){
-                service {'idmapd' :
-                    ensure => running,
-                    subscribe => File['/etc/idmapd.conf'],
-                    require => [Package['nfs-common']],
-                }
-            }
-       }
-       else {
-            if !defined(Service["nfs-common"]){
-                service {'nfs-common' :
-                    ensure => running,
-                    subscribe => File['/etc/idmapd.conf']
-                }
-            }
       }
-      
+    }
+    else {
+      if !defined(Service['nfs-common']){
+        service {'nfs-common' :
+          ensure    => running,
+          subscribe => File['/etc/idmapd.conf']
+        }
+      }
+    }
+
     if !defined(File['idmapd.conf']){
-        file { 'idmapd.conf' :
-            path    => "/etc/idmapd.conf",
-            ensure => 'file',
-            content  => template('atomia/nfsmount/idmapd.conf'),
-        }  
+      file { 'idmapd.conf' :
+        ensure  => 'file',
+        path    => '/etc/idmapd.conf',
+        content => template('atomia/nfsmount/idmapd.conf'),
+      }
     }
     if !defined(File['nfs-common']){
-        file { 'nfs-common' :
-            path    => "/etc/default/nfs-common",
-            ensure => 'file',
-            content  => template('atomia/nfsmount/nfs-common'),
-        }
-    }      
-               
+      file { 'nfs-common' :
+        ensure  => 'file',
+        path    => '/etc/default/nfs-common',
+        content => template('atomia/nfsmount/nfs-common'),
+      }
+    }
+
     }# CloudLinux specifics
     else
     {
-        if !defined(Package['nfs-utils']) {
-            package { nfs-utils: ensure => present }
-        }
-        
-        mount { $mount_point:
-            device => $nfs_location,
-            fstype => $fs_type,
-            remounts => false,
-            options => $nfs_options,
-            ensure => mounted,
-            require => [File[$mount_point]],
-        }        
+      if !defined(Package['nfs-utils']) {
+        package { 'nfs-utils': ensure => present }
+      }
+
+      mount { $mount_point:
+        ensure   => mounted,
+        device   => $nfs_location,
+        fstype   => $fs_type,
+        remounts => false,
+        options  => $nfs_options,
+        require  => [File[$mount_point]],
+      }
     }
 
 }

--- a/manifests/openstack.pp
+++ b/manifests/openstack.pp
@@ -27,16 +27,16 @@
 ##### external_gateway: .*
 
 class atomia::openstack (
-	$admin_user        = "admin",
-	$admin_password,    
-	$domain			   = "Default",
-    $identity_uri,
-    $compute_uri,
-    $network_uri,
-    $ceilometer_uri,
-    $cinder_uri,
-    $hypervisor        = "kvm",
-    $external_gateway  = "",
+  $admin_user       = 'admin',
+  $admin_password,
+  $domain           = 'Default',
+  $identity_uri,
+  $compute_uri,
+  $network_uri,
+  $ceilometer_uri,
+  $cinder_uri,
+  $hypervisor       = 'kvm',
+  $external_gateway = '',
 ){
 
 }

--- a/manifests/phpmyadmin.pp
+++ b/manifests/phpmyadmin.pp
@@ -1,77 +1,77 @@
 class atomia::phpmyadmin (
-	$mysql_host
+  $mysql_host
 ){
-	package { phpmyadmin: ensure => present }
-	package { apache2: ensure => present } 
-	package { libapache2-mod-php5: ensure => present }
-	 file { "/etc/phpmyadmin/config.inc.php":
-                owner   => root,
-                group   => root,
-                mode    => "444",
-		content => template('atomia/phpmyadmin/config.inc.php'),
-                require => Package["phpmyadmin"],
-        }
-
-	
-        file { "/etc/apache2/sites-available/phpmyadmin-default":
-                owner   => root,
-                group   => root,
-                mode    => "444",
-                source  => "puppet:///modules/atomia/phpmyadmin/default",
-                require => Package["apache2"],
-        }
+  package { 'phpmyadmin': ensure => present }
+  package { 'apache2': ensure => present }
+  package { 'libapache2-mod-php5': ensure => present }
+  file { '/etc/phpmyadmin/config.inc.php':
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0444',
+    content => template('atomia/phpmyadmin/config.inc.php'),
+    require => Package['phpmyadmin'],
+  }
 
 
-        file { "/etc/apache2/sites-enabled/phpmyadmin-default":
-                owner   => root,
-                group   => root,
-                mode    => "444",
-                ensure => link,
-                target => "/etc/apache2/sites-available/phpmyadmin-default",
-                require => [File["/etc/apache2/sites-available/phpmyadmin-default"],
-				Package["apache2"]],
-                notify  => Service["apache2"],
-        }
+  file { '/etc/apache2/sites-available/phpmyadmin-default':
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0444',
+    source  => 'puppet:///modules/atomia/phpmyadmin/default',
+    require => Package['apache2'],
+  }
 
 
-        if !defined(File['/etc/apache2/sites-enabled/000-default']) {
-                file { "/etc/apache2/sites-enabled/000-default":
-                        ensure  => absent,
-                        require => Package["apache2"],
-                        notify => Service["apache2"],
-                }
-        }
+  file { '/etc/apache2/sites-enabled/phpmyadmin-default':
+    ensure  => link,
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0444',
+    target  => '/etc/apache2/sites-available/phpmyadmin-default',
+    require => [File['/etc/apache2/sites-available/phpmyadmin-default'],
+    Package['apache2']],
+    notify  => Service['apache2'],
+  }
 
-        if !defined(File['/etc/apache2/sites-available/default']) {
-                file { "/etc/apache2/sites-available/default":
-                        ensure  => absent,
-                        require => Package["apache2"],
-                        notify => Service["apache2"],
-                }
-        }
 
-        file { "/etc/php5/apache2/php.ini":
-               owner   => root,
-               group   => root,
-               mode    => "644",
-	       source  => "puppet:///modules/atomia/phpmyadmin/php.ini",
-               require => Package["apache2"],
-               notify  => Service["apache2"],
-        }
+  if !defined(File['/etc/apache2/sites-enabled/000-default']) {
+    file { '/etc/apache2/sites-enabled/000-default':
+      ensure  => absent,
+      require => Package['apache2'],
+      notify  => Service['apache2'],
+    }
+  }
 
-        exec { "force-reload-apache-phpmyadmin":
-                refreshonly => true,
-                before => Service["apache2"],
-                command => "/etc/init.d/apache2 force-reload",
-        }
+  if !defined(File['/etc/apache2/sites-available/default']) {
+    file { '/etc/apache2/sites-available/default':
+      ensure  => absent,
+      require => Package['apache2'],
+      notify  => Service['apache2'],
+    }
+  }
 
-        exec { "/usr/sbin/a2enmod php5":
-                unless => "/usr/bin/test -f /etc/apache2/mods-enabled/php5.load",
-                require => Package["libapache2-mod-php5"],
-                notify => Exec["force-reload-apache-phpmyadmin"],
-        }
+  file { '/etc/php5/apache2/php.ini':
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    source  => 'puppet:///modules/atomia/phpmyadmin/php.ini',
+    require => Package['apache2'],
+    notify  => Service['apache2'],
+  }
 
-	service { 'apache2':
-		ensure => running,
-	}
+  exec { 'force-reload-apache-phpmyadmin':
+    refreshonly => true,
+    before      => Service['apache2'],
+    command     => '/etc/init.d/apache2 force-reload',
+  }
+
+  exec { '/usr/sbin/a2enmod php5':
+    unless  => '/usr/bin/test -f /etc/apache2/mods-enabled/php5.load',
+    require => Package['libapache2-mod-php5'],
+    notify  => Exec['force-reload-apache-phpmyadmin'],
+  }
+
+  service { 'apache2':
+    ensure => running,
+  }
 }

--- a/manifests/postgresql.pp
+++ b/manifests/postgresql.pp
@@ -11,22 +11,22 @@
 ##### postgresql_password(advanced): %password
 
 class atomia::postgresql (
-	$postgresql_username = "automationserver",
-	$postgresql_password
-	){
+  $postgresql_username = 'automationserver',
+  $postgresql_password
+){
 
-	class { 'postgresql::server':
-		ip_mask_deny_postgres_user => '0.0.0.0/32',
-		ip_mask_allow_all_users    => '0.0.0.0/0',
-		listen_addresses           => '*',
-		ipv4acls                   => ['host all all 0.0.0.0/0 md5']
-	}
+  class { 'postgresql::server':
+    ip_mask_deny_postgres_user => '0.0.0.0/32',
+    ip_mask_allow_all_users    => '0.0.0.0/0',
+    listen_addresses           => '*',
+    ipv4acls                   => ['host all all 0.0.0.0/0 md5']
+  }
 
-	postgresql::server::role { 'atomia_postgresql_provisioning_user':
-		username => $postgresql_username,
-		password_hash => postgresql_password($postgresql_username, $postgresql_password),
-		createdb => true,
-		createrole => true,
-		superuser => true
-	}
+  postgresql::server::role { 'atomia_postgresql_provisioning_user':
+    username      => $postgresql_username,
+    password_hash => postgresql_password($postgresql_username, $postgresql_password),
+    createdb      => true,
+    createrole    => true,
+    superuser     => true
+  }
 }

--- a/manifests/public_apps.pp
+++ b/manifests/public_apps.pp
@@ -10,63 +10,63 @@
 
 
 class atomia::public_apps (
-  $repository = "PublicRepository",){
+  $repository = 'PublicRepository',){
 
-  # Set ip correctly when on ec2
-  if $ec2_public_ipv4 {
-    $public_ip = $ec2_public_ipv4
-  } else {
-    $public_ip = $ipaddress_eth0
-  }
+    # Set ip correctly when on ec2
+    if $::ec2_public_ipv4 {
+      $public_ip = $::ec2_public_ipv4
+    } else {
+      $public_ip = $::ipaddress_eth0
+    }
 
     File { source_permissions => ignore }
 
 
     if($repository == 'PublicRepository')
     {
-        exec {'install-identity':
-            command => 'C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe -Executionpolicy Unrestricted -File c:/install/install_atomia_application.ps1 -repository PublicRepository -application "Atomia Identity"',
-            require   => [Exec['install-setuptools'],File['unattended.ini']],
-            creates => 'C:\Program Files (x86)\Atomia\Identity',
-        }
-        ->
-        exec {'install-hcp':
-            command => 'C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe -Executionpolicy Unrestricted -File c:/install/install_atomia_application.ps1 -repository PublicRepository -application "Atomia Hosting Control Panel"',
-            require   => [Exec['install-identity'],File['unattended.ini']],
-            creates => 'C:\Program Files (x86)\Atomia\HostingControlPanel',
-        }
-        ->
-        exec {'install-bcp':
-            command => 'C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe -Executionpolicy Unrestricted -File c:/install/install_atomia_application.ps1 -repository PublicRepository -application "Atomia Billing Customer Panel"',
-            require   => [Exec['install-identity'],File['unattended.ini']],
-            creates => 'C:\Program Files (x86)\Atomia\BillingCustomerPanel',
-        }
-        ## TODO: Add store when available
+      exec {'install-identity':
+        command => 'C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe -Executionpolicy Unrestricted -File c:/install/install_atomia_application.ps1 -repository PublicRepository -application "Atomia Identity"',
+        require => [Exec['install-setuptools'],File['unattended.ini']],
+        creates => 'C:\Program Files (x86)\Atomia\Identity',
+      }
+    ->
+    exec {'install-hcp':
+      command => 'C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe -Executionpolicy Unrestricted -File c:/install/install_atomia_application.ps1 -repository PublicRepository -application "Atomia Hosting Control Panel"',
+      require => [Exec['install-identity'],File['unattended.ini']],
+      creates => 'C:\Program Files (x86)\Atomia\HostingControlPanel',
+    }
+  ->
+  exec {'install-bcp':
+    command => 'C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe -Executionpolicy Unrestricted -File c:/install/install_atomia_application.ps1 -repository PublicRepository -application "Atomia Billing Customer Panel"',
+    require => [Exec['install-identity'],File['unattended.ini']],
+    creates => 'C:\Program Files (x86)\Atomia\BillingCustomerPanel',
+  }
+  ## TODO: Add store when available
 
+  }
+  else
+  {
+    exec {'install-identity':
+      command => 'C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe -Executionpolicy Unrestricted -File c:/install/install_atomia_application.ps1 -repository TestRepository -application "Atomia Identity"',
+      require => [Exec['install-setuptools'],File['unattended.ini']],
+      creates => 'C:\Program Files (x86)\Atomia\Identity',
     }
-    else
-    {
-        exec {'install-identity':
-            command => 'C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe -Executionpolicy Unrestricted -File c:/install/install_atomia_application.ps1 -repository TestRepository -application "Atomia Identity"',
-            require   => [Exec['install-setuptools'],File['unattended.ini']],
-            creates => 'C:\Program Files (x86)\Atomia\Identity',
-        }
-        ->
-        exec {'install-hcp':
-            command => 'C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe -Executionpolicy Unrestricted -File c:/install/install_atomia_application.ps1 -repository TestRepository -application "Atomia Hosting Control Panel"',
-            require   => [Exec['install-identity'],File['unattended.ini']],
-            creates => 'C:\Program Files (x86)\Atomia\HostingControlPanel',
-        }
-        ->
-        exec {'install-bcp':
-            command => 'C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe -Executionpolicy Unrestricted -File c:/install/install_atomia_application.ps1 -repository TestRepository -application "Atomia Billing Customer Panel"',
-            require   => [Exec['install-identity'],File['unattended.ini']],
-            creates => 'C:\Program Files (x86)\Atomia\BillingCustomerPanel',
-        }
-    }
-
-    file { 'C:\ProgramData\PuppetLabs\facter\facts.d\atomia_role_public.txt':
-      content => 'atomia_role_1=atomia_public_apps',
-    }
+  ->
+  exec {'install-hcp':
+    command => 'C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe -Executionpolicy Unrestricted -File c:/install/install_atomia_application.ps1 -repository TestRepository -application "Atomia Hosting Control Panel"',
+    require => [Exec['install-identity'],File['unattended.ini']],
+    creates => 'C:\Program Files (x86)\Atomia\HostingControlPanel',
+  }
+->
+exec {'install-bcp':
+  command => 'C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe -Executionpolicy Unrestricted -File c:/install/install_atomia_application.ps1 -repository TestRepository -application "Atomia Billing Customer Panel"',
+  require => [Exec['install-identity'],File['unattended.ini']],
+  creates => 'C:\Program Files (x86)\Atomia\BillingCustomerPanel',
 }
+  }
+
+  file { 'C:\ProgramData\PuppetLabs\facter\facts.d\atomia_role_public.txt':
+    content => 'atomia_role_1=atomia_public_apps',
+  }
+  }
 

--- a/manifests/pureftpd.pp
+++ b/manifests/pureftpd.pp
@@ -10,7 +10,7 @@
 #### pureftpd_password: The password for the MySQL user with the name pureftpd that the FTP server connects to the user database as.
 #### ftp_cluster_ip: The virtual IP of the FTP cluster.
 #### content_share_nfs_location: The location of the NFS share for customer website content. Leave blank if using the default setup with GlusterFS
-#### is_master: Toggles if we are provisioning the master FTP node (with the main user database) or a slave node (with a replicated database). 
+#### is_master: Toggles if we are provisioning the master FTP node (with the main user database) or a slave node (with a replicated database).
 #### pureftpd_slave_password: The password for the MySQL user with the name slave_user that the user database replication uses.
 #### mysql_root_password: The password for the MySQL root user.
 #### ssl_enabled: Toggles if we are to configure SSL for the FTP service.
@@ -35,333 +35,331 @@
 ##### passive_port_range(advanced): ^[0-9]+ [0-9]+$
 
 class atomia::pureftpd (
-	$agent_user	 		= "automationserver",
-	$agent_password,
-	$master_ip			= $ipaddress,
-	$provisioning_host		= "%",
-	$pureftpd_password,
-	$ftp_cluster_ip,
-	$content_share_nfs_location	= '',
-	$is_master			= 1,
-	$pureftpd_slave_password,
-	$mysql_root_password,
-	$ssl_enabled			= 0,
-	$skip_mount			= 0,
-	$content_mount_point		= "/storage/content",
-	$passive_port_range		= "49152 65534"
+  $agent_user                 = 'automationserver',
+  $agent_password,
+  $master_ip                  = $ipaddress,
+  $provisioning_host          = '%',
+  $pureftpd_password,
+  $ftp_cluster_ip,
+  $content_share_nfs_location = '',
+  $is_master                  = 1,
+  $pureftpd_slave_password,
+  $mysql_root_password,
+  $ssl_enabled                = 0,
+  $skip_mount                 = 0,
+  $content_mount_point        = '/storage/content',
+  $passive_port_range         = '49152 65534'
 ){
 
-	package { pure-ftpd-mysql: ensure => installed }
-	package { xinetd: ensure => installed }
+  package { 'pure-ftpd-mysql': ensure => installed }
+  package { 'xinetd': ensure => installed }
 
-	if $skip_mount == 0 {
-				
-		if $content_share_nfs_location == '' {
-			$internal_zone = hiera('atomia::internaldns::zone_name','')
-			package { 'glusterfs-client': ensure => present, }
-			
-			if !defined(File["/storage"]) {
-				file { "/storage":
-				ensure => directory,
-				}
-			}
-			
-			fstab::mount { '/storage/content':
-				ensure  => 'mounted',
-				device  => "gluster.${internal_zone}:/web_volume",
-				options => 'defaults,_netdev',
-				fstype  => 'glusterfs',
-				require => [Package['glusterfs-client'],File["/storage"]],
-			}			
-    	}
-		else
-		{
-			atomia::nfsmount { 'mount_content':
-				use_nfs3		 => 1,
-				mount_point  => '/storage/content',
-				nfs_location => $content_share_nfs_location
-			}
-		}
-	}
+  if $skip_mount == 0 {
 
-	if $is_master == 1 {
-        $override_options = {
-				'mysqld' => {
-					'server_id'	=> '1',
-					'log_bin'	=> '/var/log/mysql/mysql-bin.log',
-					'binlog_do_db'	=> 'pureftpd',
-                    'expire_logs_days' => 5,
-					'bind-address'	=> "${master_ip}",
-				}
-			}
-		class { 'mysql::server':
-			restart			=> true,
-			root_password		=> $mysql_root_password,
-			remove_default_accounts	=> true,
-            override_options        => $override_options
+    if $content_share_nfs_location == '' {
+      $internal_zone = hiera('atomia::internaldns::zone_name','')
+      package { 'glusterfs-client': ensure => present, }
 
-		}
+      if !defined(File['/storage']) {
+        file { '/storage':
+          ensure => directory,
+        }
+      }
 
-		mysql_user { "create-automationserver-user":
-			name		=> "$agent_user@$provisioning_host",
-			ensure		=> 'present',
-			password_hash	=> mysql_password($pureftpd_password),
-			require		=> Class[Mysql::Server::Service],
-		}
+      fstab::mount { '/storage/content':
+        ensure  => 'mounted',
+        device  => "gluster.${internal_zone}:/web_volume",
+        options => 'defaults,_netdev',
+        fstype  => 'glusterfs',
+        require => [Package['glusterfs-client'],File['/storage']],
+      }
+    }
+    else
+    {
+      atomia::nfsmount { 'mount_content':
+        use_nfs3     => 1,
+        mount_point  => '/storage/content',
+        nfs_location => $content_share_nfs_location
+      }
+    }
+  }
 
-		mysql_grant { "$agent_user@$provisioning_host/pureftpd.*":
-			ensure		=> 'present',
-			options		=> ['GRANT'],
-			privileges	=> ['INSERT', 'SELECT', 'UPDATE', 'DELETE'],
-			table		=> 'pureftpd.*',
-			user		=> "$agent_user@$provisioning_host",
-			require		=> Mysql_database['create-pureftpd-database']
-		}
+  if $is_master == 1 {
+    $override_options = {
+      'mysqld' => {
+        'server_id'  => '1',
+        'log_bin'  => '/var/log/mysql/mysql-bin.log',
+        'binlog_do_db'  => 'pureftpd',
+        'expire_logs_days' => 5,
+        'bind-address'  => $master_ip,
+      }
+    }
+    class { 'mysql::server':
+      restart                 => true,
+      root_password           => $mysql_root_password,
+      remove_default_accounts => true,
+      override_options        => $override_options
 
-		mysql_user { "create-slave-user":
-			name		=> "slave_user@%",
-			ensure		=> 'present',
-			password_hash	=> mysql_password($pureftpd_slave_password),
-			require		=> Class[Mysql::Server::Service],
-		}
+    }
 
-		mysql_grant { "slave_user@%/*.*":
-			ensure		=> 'present',
-			options		=> ['GRANT'],
-			privileges	=> ['ALL', 'REPLICATION SLAVE'],
-			table		=> '*.*',
-			user		=> "slave_user@%",
-			require		=> Class[Mysql::Server::Service],
-		}
+    mysql_user { 'create-automationserver-user':
+      ensure        => 'present',
+      name          => "${agent_user}@${provisioning_host}",
+      password_hash => mysql_password($pureftpd_password),
+      require       => Class[Mysql::Server::Service],
+    }
+
+    mysql_grant { "${agent_user}@${provisioning_host}/pureftpd.*":
+      ensure     => 'present',
+      options    => ['GRANT'],
+      privileges => ['INSERT', 'SELECT', 'UPDATE', 'DELETE'],
+      table      => 'pureftpd.*',
+      user       => "${agent_user}@${provisioning_host}",
+      require    => Mysql_database['create-pureftpd-database']
+    }
+
+    mysql_user { 'create-slave-user':
+      ensure        => 'present',
+      name          => 'slave_user@%',
+      password_hash => mysql_password($pureftpd_slave_password),
+      require       => Class[Mysql::Server::Service],
+    }
+
+    mysql_grant { 'slave_user@%/*.*':
+      ensure     => 'present',
+      options    => ['GRANT'],
+      privileges => ['ALL', 'REPLICATION SLAVE'],
+      table      => '*.*',
+      user       => 'slave_user@%',
+      require    => Class[Mysql::Server::Service],
+    }
 
 
-		exec { 'setup-master':
-			command	=> "/etc/pure-ftpd/setup_database.sh master",
-			require	=> [
-				File["/etc/pure-ftpd/setup_database.sh"],
-				Class[Mysql::Server::Service],
-				File["/etc/pure-ftpd/mysql.schema.sql"],
-				Mysql_database['create-pureftpd-database'],
-				Mysql_grant["slave_user@%/*.*"]
-			],
-			unless	=> "/etc/pure-ftpd/setup_database.sh master_is_done",
-		}
+    exec { 'setup-master':
+      command => '/etc/pure-ftpd/setup_database.sh master',
+      require => [
+        File['/etc/pure-ftpd/setup_database.sh'],
+        Class[Mysql::Server::Service],
+        File['/etc/pure-ftpd/mysql.schema.sql'],
+        Mysql_database['create-pureftpd-database'],
+        Mysql_grant['slave_user@%/*.*']
+      ],
+      unless  => '/etc/pure-ftpd/setup_database.sh master_is_done',
+    }
 
-		file { "/etc/pure-ftpd/mysql.schema.sql":
-			owner		=> root,
-			group		=> root,
-			mode		=> "400",
-			source		=> "puppet:///modules/atomia/pureftpd/mysql.schema.sql",
-			require 	=> Package["pure-ftpd-mysql"],
-		}
-	} else {
-		# Slave config
-		class { 'mysql::server':
-			restart			=> true,
-			root_password		=> $mysql_root_password,
-			remove_default_accounts	=> true,
-			override_options	=> {
-				mysqld => {
-					'server_id'	=> '2',
-					'log_bin'	=> '/var/log/mysql/mysql-bin.log',
-					'binlog_do_db'	=> 'pureftpd',
-				}
-			}
-		}
+    file { '/etc/pure-ftpd/mysql.schema.sql':
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0400',
+      source  => 'puppet:///modules/atomia/pureftpd/mysql.schema.sql',
+      require => Package['pure-ftpd-mysql'],
+    }
+  } else {
+    # Slave config
+    class { 'mysql::server':
+      restart                 => true,
+      root_password           => $mysql_root_password,
+      remove_default_accounts => true,
+      override_options        => {
+        mysqld => {
+          'server_id'    => '2',
+          'log_bin'      => '/var/log/mysql/mysql-bin.log',
+          'binlog_do_db' => 'pureftpd',
+        }
+      }
+    }
 
-		exec { 'setup-slave':
-			command	=> "/etc/pure-ftpd/setup_database.sh slave",
-			require	=> [
-				File["/etc/pure-ftpd/setup_database.sh"],
-				Class[Mysql::Server::Service],
-				Mysql_database['create-pureftpd-database'],
-				Mysql_grant['pureftpd@localhost/pureftpd.*'],
-			],
-			unless	=> "/etc/pure-ftpd/setup_database.sh slave_is_done",
-		}
-	}
+    exec { 'setup-slave':
+      command => '/etc/pure-ftpd/setup_database.sh slave',
+      require => [
+        File['/etc/pure-ftpd/setup_database.sh'],
+        Class[Mysql::Server::Service],
+        Mysql_database['create-pureftpd-database'],
+        Mysql_grant['pureftpd@localhost/pureftpd.*'],
+      ],
+      unless  => '/etc/pure-ftpd/setup_database.sh slave_is_done',
+    }
+  }
 
-	mysql_database { "create-pureftpd-database":
-		name	=> "pureftpd",
-		ensure	=> "present",
-		require	=> Class[Mysql::Server::Service],
-	}
+  mysql_database { 'create-pureftpd-database':
+    ensure  => 'present',
+    name    => 'pureftpd',
+    require => Class[Mysql::Server::Service],
+  }
 
-	mysql_user { "create-pureftpd-user":
-		name		=> "pureftpd@localhost",
-		ensure		=> 'present',
-		password_hash	=> mysql_password($pureftpd_password),
-		require		=> Class[Mysql::Server::Service],
-	}
+  mysql_user { 'create-pureftpd-user':
+    ensure        => 'present',
+    name          => 'pureftpd@localhost',
+    password_hash => mysql_password($pureftpd_password),
+    require       => Class[Mysql::Server::Service],
+  }
 
-	mysql_grant { "pureftpd@localhost/pureftpd.*":
-		ensure		=> 'present',
-		options		=> ['GRANT'],
-		privileges	=> ['ALL'],
-		table		=> 'pureftpd.*',
-		user		=> "pureftpd@localhost",
-		require		=> Mysql_database['create-pureftpd-database']
-	}
+  mysql_grant { 'pureftpd@localhost/pureftpd.*':
+    ensure     => 'present',
+    options    => ['GRANT'],
+    privileges => ['ALL'],
+    table      => 'pureftpd.*',
+    user       => 'pureftpd@localhost',
+    require    => Mysql_database['create-pureftpd-database']
+  }
 
-	file { "/etc/pure-ftpd/setup_database.sh":
-		owner		=> root,
-		group		=> root,
-		mode		=> "500",
-		content		=> template("atomia/pure-ftpd/setup_database.sh.erb"),
-		require		=> Package["pure-ftpd-mysql"],
-	}
+  file { '/etc/pure-ftpd/setup_database.sh':
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0500',
+    content => template('atomia/pure-ftpd/setup_database.sh.erb'),
+    require => Package['pure-ftpd-mysql'],
+  }
 
-	file { "/etc/pure-ftpd/db/mysql.conf":
-		owner		=> root,
-		group		=> root,
-		mode		=> "400",
-		content		=> template("atomia/pure-ftpd/mysqlsettings.cfg.erb"),
-		require		=> Package["pure-ftpd-mysql"],
-		notify		=> Service["pure-ftpd-mysql"],
-	}
+  file { '/etc/pure-ftpd/db/mysql.conf':
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0400',
+    content => template('atomia/pure-ftpd/mysqlsettings.cfg.erb'),
+    require => Package['pure-ftpd-mysql'],
+    notify  => Service['pure-ftpd-mysql'],
+  }
 
-	file { "/etc/pure-ftpd/conf/ChrootEveryone":
-		owner		=> root,
-		group		=> root,
-		mode		=> "444",
-		content 	=> "yes",
-		require 	=> Package["pure-ftpd-mysql"],
-		notify		=> Service["pure-ftpd-mysql"],
-	}
+  file { '/etc/pure-ftpd/conf/ChrootEveryone':
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0444',
+    content => 'yes',
+    require => Package['pure-ftpd-mysql'],
+    notify  => Service['pure-ftpd-mysql'],
+  }
 
-	file { "/etc/pure-ftpd/conf/CreateHomeDir":
-		owner		=> root,
-		group		=> root,
-		mode		=> "444",
-		content		=> "yes",
-		require		=> Package["pure-ftpd-mysql"],
-		notify		=> Service["pure-ftpd-mysql"],
-	}
+  file { '/etc/pure-ftpd/conf/CreateHomeDir':
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0444',
+    content => 'yes',
+    require => Package['pure-ftpd-mysql'],
+    notify  => Service['pure-ftpd-mysql'],
+  }
 
-	file { "/etc/pure-ftpd/conf/DontResolve":
-		owner		=> root,
-		group		=> root,
-		mode		=> "444",
-		content 	=> "yes",
-		require 	=> Package["pure-ftpd-mysql"],
-		notify		=> Service["pure-ftpd-mysql"],
-	}
+  file { '/etc/pure-ftpd/conf/DontResolve':
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0444',
+    content => 'yes',
+    require => Package['pure-ftpd-mysql'],
+    notify  => Service['pure-ftpd-mysql'],
+  }
 
-	file { "/etc/pure-ftpd/conf/MaxClientsNumber":
-		owner		=> root,
-		group		=> root,
-		mode		=> "444",
-		content 	=> "150",
-		require 	=> Package["pure-ftpd-mysql"],
-		notify		=> Service["pure-ftpd-mysql"],
-	}
+  file { '/etc/pure-ftpd/conf/MaxClientsNumber':
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0444',
+    content => '150',
+    require => Package['pure-ftpd-mysql'],
+    notify  => Service['pure-ftpd-mysql'],
+  }
 
-	file { "/etc/pure-ftpd/conf/DisplayDotFiles":
-		owner		=> root,
-		group		=> root,
-		mode		=> "444",
-		content 	=> "yes",
-		require 	=> Package["pure-ftpd-mysql"],
-		notify		=> Service["pure-ftpd-mysql"],
-	}
+  file { '/etc/pure-ftpd/conf/DisplayDotFiles':
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0444',
+    content => 'yes',
+    require => Package['pure-ftpd-mysql'],
+    notify  => Service['pure-ftpd-mysql'],
+  }
 
-	file { "/etc/pure-ftpd/conf/PassivePortRange":
-		owner		=> root,
-		group		=> root,
-		mode		=> "444",
-		content 	=> $passive_port_range,
-		require 	=> Package["pure-ftpd-mysql"],
-		notify		=> Service["pure-ftpd-mysql"],
-	}
+  file { '/etc/pure-ftpd/conf/PassivePortRange':
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0444',
+    content => $passive_port_range,
+    require => Package['pure-ftpd-mysql'],
+    notify  => Service['pure-ftpd-mysql'],
+  }
 
-	file { "/etc/pure-ftpd/conf/LimitRecursion":
-		owner	=> root,
-		group	=> root,
-		mode	=> "444",
-		content	=> "15000 15",
-		require	=> Package["pure-ftpd-mysql"],
-		notify	=> Service["pure-ftpd-mysql"],
-	}
+  file { '/etc/pure-ftpd/conf/LimitRecursion':
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0444',
+    content => '15000 15',
+    require => Package['pure-ftpd-mysql'],
+    notify  => Service['pure-ftpd-mysql'],
+  }
 
-	file { "/etc/pure-ftpd/conf/ForcePassiveIP":
-		owner	=> root,
-		group	=> root,
-		mode	=> "444",
-		content	=> "$ftp_cluster_ip",
-		require	=> Package["pure-ftpd-mysql"],
-		notify	=> Service["pure-ftpd-mysql"],
-	}
+  file { '/etc/pure-ftpd/conf/ForcePassiveIP':
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0444',
+    content => $ftp_cluster_ip,
+    require => Package['pure-ftpd-mysql'],
+    notify  => Service['pure-ftpd-mysql'],
+  }
 
-	service { pure-ftpd-mysql:
-		name		=> pure-ftpd-mysql,
-		pattern		=> "pure-ftpd.*",
-		enable		=> true,
-		ensure		=> running,
-		subscribe	=> [
-			Package["pure-ftpd-mysql"],
-			File["/etc/pure-ftpd/db/mysql.conf"],
-			File["/etc/pure-ftpd/conf/ChrootEveryone"],
-			File["/etc/pure-ftpd/conf/CreateHomeDir"],
-			File["/etc/pure-ftpd/conf/DontResolve"],
-			File["/etc/pure-ftpd/conf/PassivePortRange"]
-		],
-	}
+  service { 'pure-ftpd-mysql':
+    ensure    => running,
+    pattern   => 'pure-ftpd.*',
+    enable    => true,
+    subscribe => [
+      Package['pure-ftpd-mysql'],
+      File['/etc/pure-ftpd/db/mysql.conf'],
+      File['/etc/pure-ftpd/conf/ChrootEveryone'],
+      File['/etc/pure-ftpd/conf/CreateHomeDir'],
+      File['/etc/pure-ftpd/conf/DontResolve'],
+      File['/etc/pure-ftpd/conf/PassivePortRange']
+    ],
+  }
 
-	if $ssl_enabled != "0" {
-		file { "/etc/ssl":
-			ensure	=> directory,
-			owner	=> "root",
-			group	=> "root",
-			mode	=> "0600",
-		}
+  if $ssl_enabled != '0' {
+    file { '/etc/ssl':
+      ensure => directory,
+      owner  => 'root',
+      group  => 'root',
+      mode   => '0600',
+    }
 
-		file { "/etc/ssl/private":
-			ensure	=> directory,
-			owner	=> "root",
-			group	=> "root",
-			mode	=> "0600",
-		}
+    file { '/etc/ssl/private':
+      ensure => directory,
+      owner  => 'root',
+      group  => 'root',
+      mode   => '0600',
+    }
 
-		file { "/etc/pure-ftpd/conf/TLS":
-			owner	=> root,
-			group	=> root,
-			mode	=> "444",
-			content	=> "1",
-			require	=> Package["pure-ftpd-mysql"],
-			notify	=> Service["pure-ftpd-mysql"],
-		}
-	}
+    file { '/etc/pure-ftpd/conf/TLS':
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0444',
+      content => '1',
+      require => Package['pure-ftpd-mysql'],
+      notify  => Service['pure-ftpd-mysql'],
+    }
+  }
 
-	service { xinetd:
-		name		=> xinetd,
-		ensure		=> running,
-		subscribe => [
-			Package["xinetd"]
-		]
-	}
+  service { 'xinetd':
+    ensure    => running,
+    subscribe => [
+      Package['xinetd']
+    ]
+  }
 
-	augeas { "add-heathcheck-service":
-		changes => [
-			"ins service-name after /files/etc/services/service-name[last()]",
-			"set /files/etc/services/service-name[last()] check_ftp_health",
-			"set /files/etc/services/service-name[. = 'check_ftp_health']/port 9200",
-			"set /files/etc/services/service-name[. = 'check_ftp_health']/protocol tcp"
-		],
-		onlyif => "match /files/etc/services/service-name[. = 'check_ftp_health'] size == 0"
-	}
+  augeas { 'add-heathcheck-service':
+    changes => [
+      'ins service-name after /files/etc/services/service-name[last()]',
+      'set /files/etc/services/service-name[last()] check_ftp_health',
+      "set /files/etc/services/service-name[. = 'check_ftp_health']/port 9200",
+      "set /files/etc/services/service-name[. = 'check_ftp_health']/protocol tcp"
+    ],
+    onlyif  => "match /files/etc/services/service-name[. = 'check_ftp_health'] size == 0"
+  }
 
-	file { "/opt/check_ftp_health":
-		owner	=> nobody,
-		group	=> root,
-		mode	=> "744",
-		source	=> "puppet:///modules/atomia/pureftpd/check_ftp_health"
-	}
+  file { '/opt/check_ftp_health':
+    owner  => 'nobody',
+    group  => 'root',
+    mode   => '0744',
+    source => 'puppet:///modules/atomia/pureftpd/check_ftp_health'
+  }
 
-	file { "/etc/xinetd.d/check_ftp_health":
-		owner	=> root,
-		group	=> root,
-		source	=> "puppet:///modules/atomia/pureftpd/check_ftp_health_xinetd",
-		notify	=> Service["xinetd"],
-		require	=> Package["xinetd"]
-	}
+  file { '/etc/xinetd.d/check_ftp_health':
+    owner   => 'root',
+    group   => 'root',
+    source  => 'puppet:///modules/atomia/pureftpd/check_ftp_health_xinetd',
+    notify  => Service['xinetd'],
+    require => Package['xinetd']
+  }
 }

--- a/manifests/resource_transformations.pp
+++ b/manifests/resource_transformations.pp
@@ -1,175 +1,175 @@
 
 class atomia::resource_transformations (
-        $hierapath      = "/etc/puppet/hieradata",
-        $modulepath     = "/etc/puppet/modules/atomia/manifests",
-        $lookup_var     = "/etc/puppet/modules/atomia/files/lookup_variable.sh"
-    ) 
-  {
+  $hierapath      = '/etc/puppet/hieradata',
+  $modulepath     = '/etc/puppet/modules/atomia/manifests',
+  $lookup_var     = '/etc/puppet/modules/atomia/files/lookup_variable.sh'
+)
+{
 
-    file { 'C:/Program Files (x86)/Atomia/AutomationServer/':
-        ensure  => 'directory',
-    }
-    file { 'C:/Program Files (x86)/Atomia/AutomationServer/Common/':
-        ensure  => 'directory',
-        require => File['C:/Program Files (x86)/Atomia/AutomationServer/'],
-    }
-    file { 'C:/Program Files (x86)/Atomia/AutomationServer/Common/Transformation Files/':
-        ensure  => 'directory',
-        require => File['C:/Program Files (x86)/Atomia/AutomationServer/Common/'],
-    }
-  
-    $domainreg_url = hiera('atomia::domainreg::service_url','')
-    $domainreg_username = hiera('atomia::domainreg::service_username','')
-    $domainreg_password = hiera('atomia::domainreg::service_password','')
-    file { 'C:/Program Files (x86)/Atomia/AutomationServer/Common/Transformation Files/Resources.Domainreg.xml' :
-        content  => template('atomia/resource_transformations/Resources.Domainreg.erb'),
-        ensure => 'file',
-        require => File['C:/Program Files (x86)/Atomia/AutomationServer/Common/Transformation Files/'],
-    }
-        
-    $atomiadns_url = hiera('atomia::atomiadns::atomia_dns_url', '')
-    $atomiadns_username = hiera('atomia::atomiadns::agent_user', '')
-    $atomiadns_password = hiera('atomia::atomiadns::agent_password', '')
-    $atomiadns_nameservers = hiera('atomia::atomiadns::nameservers', '')
-    $atomiadns_nameserverGroup = hiera('atomia::atomiadns::ns_group', '')
-    file { 'C:/Program Files (x86)/Atomia/AutomationServer/Common/Transformation Files/Resources.Atomiadns.xml' :
-      ensure => 'file',
-      content  => template('atomia/resource_transformations/Resources.Atomiadns.erb'),
-      require => File['C:/Program Files (x86)/Atomia/AutomationServer/Common/Transformation Files/'],
-    }
+  file { 'C:/Program Files (x86)/Atomia/AutomationServer/':
+    ensure  => 'directory',
+  }
+  file { 'C:/Program Files (x86)/Atomia/AutomationServer/Common/':
+    ensure  => 'directory',
+    require => File['C:/Program Files (x86)/Atomia/AutomationServer/'],
+  }
+  file { 'C:/Program Files (x86)/Atomia/AutomationServer/Common/Transformation Files/':
+    ensure  => 'directory',
+    require => File['C:/Program Files (x86)/Atomia/AutomationServer/Common/'],
+  }
 
-    $activedirectory_domainName = hiera('atomia::active_directory::domain_name','')
-    $activedirectory_shortDomainName = hiera('atomia::active_directory::netbios_domain_name','')
-    $activedirectory_username = 'WindowsAdmin'
-    $activedirectory_password = hiera('atomia::active_directory::windows_admin_password','')
-    file { 'C:/Program Files (x86)/Atomia/AutomationServer/Common/Transformation Files/Resources.ActiveDirectory.xml' :
-      ensure => 'file',
-      content  => template('atomia/resource_transformations/Resources.ActiveDirectory.erb'),
-      require => File['C:/Program Files (x86)/Atomia/AutomationServer/Common/Transformation Files/'],
-    }
-    
-    $cronagent_baseUrl = hiera('atomia::cronagent::base_url', '')
-    $cronagent_token = hiera('atomia::cronagent::global_auth_token', '')
-    file { 'C:/Program Files (x86)/Atomia/AutomationServer/Common/Transformation Files/Resources.CronAgent.xml' :
-      ensure => 'file',
-      content  => template('atomia/resource_transformations/Resources.CronAgent.erb'),
-      require => File['C:/Program Files (x86)/Atomia/AutomationServer/Common/Transformation Files/'],
-    }
+  $domainreg_url      = hiera('atomia::domainreg::service_url','')
+  $domainreg_username = hiera('atomia::domainreg::service_username','')
+  $domainreg_password = hiera('atomia::domainreg::service_password','')
+  file { 'C:/Program Files (x86)/Atomia/AutomationServer/Common/Transformation Files/Resources.Domainreg.xml' :
+    ensure  => 'file',
+    content => template('atomia/resource_transformations/Resources.Domainreg.erb'),
+    require => File['C:/Program Files (x86)/Atomia/AutomationServer/Common/Transformation Files/'],
+  }
 
-    $mysql_serverIps = hiera('atomia::mysql::server_ips', '')
-    $mysql_user = hiera('atomia::mysql::mysql_username', '')
-    $mysql_password = hiera('atomia::mysql::mysql_password', '')
-    file { 'C:/Program Files (x86)/Atomia/AutomationServer/Common/Transformation Files/Resources.MySQL.xml' :
-      ensure => 'file',
-      content  => template('atomia/resource_transformations/Resources.MySQL.erb'),
-      require => File['C:/Program Files (x86)/Atomia/AutomationServer/Common/Transformation Files/'],
-    }
-    
-    $daggre_host = hiera('atomia::daggre::ip_addr', '')
-    $daggre_token = hiera('atomia::daggre::global_auth_token', '')
-    file { 'C:/Program Files (x86)/Atomia/AutomationServer/Common/Transformation Files/Resources.Daggre.xml' :
-      ensure => 'file',
-      content  => template('atomia/resource_transformations/Resources.Daggre.erb'),
-      require => File['C:/Program Files (x86)/Atomia/AutomationServer/Common/Transformation Files/'],
-    }
+  $atomiadns_url             = hiera('atomia::atomiadns::atomia_dns_url', '')
+  $atomiadns_username        = hiera('atomia::atomiadns::agent_user', '')
+  $atomiadns_password        = hiera('atomia::atomiadns::agent_password', '')
+  $atomiadns_nameservers     = hiera('atomia::atomiadns::nameservers', '')
+  $atomiadns_nameserverGroup = hiera('atomia::atomiadns::ns_group', '')
+  file { 'C:/Program Files (x86)/Atomia/AutomationServer/Common/Transformation Files/Resources.Atomiadns.xml' :
+    ensure  => 'file',
+    content => template('atomia/resource_transformations/Resources.Atomiadns.erb'),
+    require => File['C:/Program Files (x86)/Atomia/AutomationServer/Common/Transformation Files/'],
+  }
 
-    $awstats_url = hiera('atomia::awstats::server_ip','')
-    $awstats_username = hiera('atomia::awstats::agent_user','')
-    $awstats_password = hiera('atomia::awstats::agent_password','')
-    $awstats_reportip = hiera('atomia::awstats::server_ip','')
-    file { 'C:/Program Files (x86)/Atomia/AutomationServer/Common/Transformation Files/Resources.Awstats.xml' :
-      ensure => 'file',
-      content  => template('atomia/resource_transformations/Resources.Awstats.erb'),
-      require => File['C:/Program Files (x86)/Atomia/AutomationServer/Common/Transformation Files/'],
-    }
-    
-    $fsagent_username = hiera('atomia::fsagent::username','')
-    $fsagent_password = hiera('atomia::fsagent::password','')
-    $fsagent_url = hiera('atomia::fsagent::fsagent_ip','')
-    file { 'C:/Program Files (x86)/Atomia/AutomationServer/Common/Transformation Files/Resources.FSAgent.xml' :
-      ensure => 'file',
-      content  => template('atomia/resource_transformations/Resources.FSAgent.erb'),
-      require => File['C:/Program Files (x86)/Atomia/AutomationServer/Common/Transformation Files/'],
-    }
-    
-    $pureftp_databaseHost = hiera('atomia::pureftpd::master_ip','')
-    $pureftp_username = hiera('atomia::pureftpd::agent_user','')
-    $pureftp_password = hiera('atomia::pureftpd::pureftpd_password','')
-    $pureftp_clusterIp = hiera('atomia::pureftpd::ftp_cluster_ip','')
-    $pureftp_fsAgentUrl = $fsagent_url
-    $pureftp_fsagentUsername = $fsagent_username
-    $pureftp_fsagentPassword = $fsagent_password
-    $pureftp_storageRoot = hiera('atomia::pureftpd::content_mount_point','')
-    file { 'C:/Program Files (x86)/Atomia/AutomationServer/Common/Transformation Files/Resources.PureFTPD.xml' :
-      ensure => 'file',
-      content  => template('atomia/resource_transformations/Resources.PureFTPD.erb'),
-      require => File['C:/Program Files (x86)/Atomia/AutomationServer/Common/Transformation Files/'],
-    }
+  $activedirectory_domainName      = hiera('atomia::active_directory::domain_name','')
+  $activedirectory_shortDomainName = hiera('atomia::active_directory::netbios_domain_name','')
+  $activedirectory_username        = 'WindowsAdmin'
+  $activedirectory_password        = hiera('atomia::active_directory::windows_admin_password','')
+  file { 'C:/Program Files (x86)/Atomia/AutomationServer/Common/Transformation Files/Resources.ActiveDirectory.xml' :
+    ensure  => 'file',
+    content => template('atomia/resource_transformations/Resources.ActiveDirectory.erb'),
+    require => File['C:/Program Files (x86)/Atomia/AutomationServer/Common/Transformation Files/'],
+  }
 
-    $apache_url = hiera('atomia::apache_agent::apache_agent_ip', '')
-    $apache_username = hiera('atomia::apache_agent::username', '')
-    $apache_password = hiera('atomia::apache_agent::password', '')
-    $apache_clusterIp = hiera('atomia::apache_agent::cluster_ip', '')
-    file { 'C:/Program Files (x86)/Atomia/AutomationServer/Common/Transformation Files/Resources.ApacheAgent.xml' :
-      ensure => 'file',
-      content  => template('atomia/resource_transformations/Resources.ApacheAgent.erb'),
-      require => File['C:/Program Files (x86)/Atomia/AutomationServer/Common/Transformation Files/'],
-    }
-    
-    $postfix_databaseHost = hiera('atomia::mailserver::master_ip','')
-    $postfix_password = hiera('atomia::mailserver::agent_password','')
-    $postfix_clusterIp = hiera('atomia::mailserver::cluster_ip','')
-    file { 'C:/Program Files (x86)/Atomia/AutomationServer/Common/Transformation Files/Resources.MailServer.xml' :
-      ensure => 'file',
-      content  => template('atomia/resource_transformations/Resources.PostfixAndDovecot.erb'),
-      require => File['C:/Program Files (x86)/Atomia/AutomationServer/Common/Transformation Files/'],
-    }
- 
-     file { 'C:/Program Files (x86)/Atomia/AutomationServer/Common/Transformation Files/Resources.Webinstaller.xml' :
-      ensure => 'file',
-      content  => template('atomia/resource_transformations/Resources.Webinstaller.erb'),
-      require => File['C:/Program Files (x86)/Atomia/AutomationServer/Common/Transformation Files/'],
-    }
-    
+  $cronagent_baseUrl = hiera('atomia::cronagent::base_url', '')
+  $cronagent_token   = hiera('atomia::cronagent::global_auth_token', '')
+  file { 'C:/Program Files (x86)/Atomia/AutomationServer/Common/Transformation Files/Resources.CronAgent.xml' :
+    ensure  => 'file',
+    content => template('atomia/resource_transformations/Resources.CronAgent.erb'),
+    require => File['C:/Program Files (x86)/Atomia/AutomationServer/Common/Transformation Files/'],
+  }
 
-    $installatron_url = hiera('atomia::installatron::installatron_hostname','')
-    $installatron_key = hiera('atomia::installatron::authentication_key','')
-    file { 'C:/Program Files (x86)/Atomia/AutomationServer/Common/Transformation Files/Resources.Installatron.xml' :
-      ensure => 'file',
-      content  => template('atomia/resource_transformations/Resources.Installatron.erb'),
-      require => File['C:/Program Files (x86)/Atomia/AutomationServer/Common/Transformation Files/'],
-    }
-        
-    $iis_ip = hiera('atomia::iis::first_node','')
-    $iis_clusterIp = hiera('atomia::iis::cluster_ip','')
-    file { 'C:/Program Files (x86)/Atomia/AutomationServer/Common/Transformation Files/Resources.IIS.xml' :
-      ensure => 'file',
-      content  => template('atomia/resource_transformations/Resources.IIS.erb'),
-      require => File['C:/Program Files (x86)/Atomia/AutomationServer/Common/Transformation Files/'],
-    }
-    
-    $mssql_serverIps = ''
-    $mssql_username = ''
-    $mssql_password = ''
-    file { 'C:/Program Files (x86)/Atomia/AutomationServer/Common/Transformation Files/Resources.MSSQL.xml' :
-      ensure => 'file',
-      content  => template('atomia/resource_transformations/Resources.MSSQL.erb'),
-      require => File['C:/Program Files (x86)/Atomia/AutomationServer/Common/Transformation Files/'],
-    }
- 
- 	$openstack_admin_user = hiera('atomia::openstack::admin_user','')
-	$openstack_admin_password = hiera('atomia::openstack::admin_password','')   
-	$openstack_domain = hiera('atomia::openstack::domain','')   
-    $openstack_identity_uri = hiera('atomia::openstack::identity_uri','')   
-    $openstack_compute_uri = hiera('atomia::openstack::compute_uri','')   
-    $openstack_network_uri = hiera('atomia::openstack::network_uri','')   
-    $openstack_ceilometer_uri = hiera('atomia::openstack::ceilometer_uri','')   
-    $openstack_cinder_uri = hiera('atomia::openstack::cinder_uri','')   
-    $openstack_hypervisor = hiera('atomia::openstack::hypervisor','')   
-    $openstack_external_gateway = hiera('atomia::openstack::external_gateway','')   
-    file { 'C:/Program Files (x86)/Atomia/AutomationServer/Common/Transformation Files/Resources.OpenStack.xml' :
-      ensure => 'file',
-      content  => template('atomia/resource_transformations/Resources.OpenStack.erb'),
-      require => File['C:/Program Files (x86)/Atomia/AutomationServer/Common/Transformation Files/'],
-    }    
+  $mysql_serverIps = hiera('atomia::mysql::server_ips', '')
+  $mysql_user      = hiera('atomia::mysql::mysql_username', '')
+  $mysql_password  = hiera('atomia::mysql::mysql_password', '')
+  file { 'C:/Program Files (x86)/Atomia/AutomationServer/Common/Transformation Files/Resources.MySQL.xml' :
+    ensure  => 'file',
+    content => template('atomia/resource_transformations/Resources.MySQL.erb'),
+    require => File['C:/Program Files (x86)/Atomia/AutomationServer/Common/Transformation Files/'],
+  }
+
+  $daggre_host = hiera('atomia::daggre::ip_addr', '')
+  $daggre_token = hiera('atomia::daggre::global_auth_token', '')
+  file { 'C:/Program Files (x86)/Atomia/AutomationServer/Common/Transformation Files/Resources.Daggre.xml' :
+    ensure  => 'file',
+    content => template('atomia/resource_transformations/Resources.Daggre.erb'),
+    require => File['C:/Program Files (x86)/Atomia/AutomationServer/Common/Transformation Files/'],
+  }
+
+  $awstats_url      = hiera('atomia::awstats::server_ip','')
+  $awstats_username = hiera('atomia::awstats::agent_user','')
+  $awstats_password = hiera('atomia::awstats::agent_password','')
+  $awstats_reportip = hiera('atomia::awstats::server_ip','')
+  file { 'C:/Program Files (x86)/Atomia/AutomationServer/Common/Transformation Files/Resources.Awstats.xml' :
+    ensure  => 'file',
+    content => template('atomia/resource_transformations/Resources.Awstats.erb'),
+    require => File['C:/Program Files (x86)/Atomia/AutomationServer/Common/Transformation Files/'],
+  }
+
+  $fsagent_username = hiera('atomia::fsagent::username','')
+  $fsagent_password = hiera('atomia::fsagent::password','')
+  $fsagent_url      = hiera('atomia::fsagent::fsagent_ip','')
+  file { 'C:/Program Files (x86)/Atomia/AutomationServer/Common/Transformation Files/Resources.FSAgent.xml' :
+    ensure  => 'file',
+    content => template('atomia/resource_transformations/Resources.FSAgent.erb'),
+    require => File['C:/Program Files (x86)/Atomia/AutomationServer/Common/Transformation Files/'],
+  }
+
+  $pureftp_databaseHost    = hiera('atomia::pureftpd::master_ip','')
+  $pureftp_username        = hiera('atomia::pureftpd::agent_user','')
+  $pureftp_password        = hiera('atomia::pureftpd::pureftpd_password','')
+  $pureftp_clusterIp       = hiera('atomia::pureftpd::ftp_cluster_ip','')
+  $pureftp_fsAgentUrl      = $fsagent_url
+  $pureftp_fsagentUsername = $fsagent_username
+  $pureftp_fsagentPassword = $fsagent_password
+  $pureftp_storageRoot     = hiera('atomia::pureftpd::content_mount_point','')
+  file { 'C:/Program Files (x86)/Atomia/AutomationServer/Common/Transformation Files/Resources.PureFTPD.xml' :
+    ensure  => 'file',
+    content => template('atomia/resource_transformations/Resources.PureFTPD.erb'),
+    require => File['C:/Program Files (x86)/Atomia/AutomationServer/Common/Transformation Files/'],
+  }
+
+  $apache_url       = hiera('atomia::apache_agent::apache_agent_ip', '')
+  $apache_username  = hiera('atomia::apache_agent::username', '')
+  $apache_password  = hiera('atomia::apache_agent::password', '')
+  $apache_clusterIp = hiera('atomia::apache_agent::cluster_ip', '')
+  file { 'C:/Program Files (x86)/Atomia/AutomationServer/Common/Transformation Files/Resources.ApacheAgent.xml' :
+    ensure  => 'file',
+    content => template('atomia/resource_transformations/Resources.ApacheAgent.erb'),
+    require => File['C:/Program Files (x86)/Atomia/AutomationServer/Common/Transformation Files/'],
+  }
+
+  $postfix_databaseHost = hiera('atomia::mailserver::master_ip','')
+  $postfix_password     = hiera('atomia::mailserver::agent_password','')
+  $postfix_clusterIp    = hiera('atomia::mailserver::cluster_ip','')
+  file { 'C:/Program Files (x86)/Atomia/AutomationServer/Common/Transformation Files/Resources.MailServer.xml' :
+    ensure  => 'file',
+    content => template('atomia/resource_transformations/Resources.PostfixAndDovecot.erb'),
+    require => File['C:/Program Files (x86)/Atomia/AutomationServer/Common/Transformation Files/'],
+  }
+
+  file { 'C:/Program Files (x86)/Atomia/AutomationServer/Common/Transformation Files/Resources.Webinstaller.xml' :
+    ensure  => 'file',
+    content => template('atomia/resource_transformations/Resources.Webinstaller.erb'),
+    require => File['C:/Program Files (x86)/Atomia/AutomationServer/Common/Transformation Files/'],
+  }
+
+
+  $installatron_url = hiera('atomia::installatron::installatron_hostname','')
+  $installatron_key = hiera('atomia::installatron::authentication_key','')
+  file { 'C:/Program Files (x86)/Atomia/AutomationServer/Common/Transformation Files/Resources.Installatron.xml' :
+    ensure  => 'file',
+    content => template('atomia/resource_transformations/Resources.Installatron.erb'),
+    require => File['C:/Program Files (x86)/Atomia/AutomationServer/Common/Transformation Files/'],
+  }
+
+  $iis_ip        = hiera('atomia::iis::first_node','')
+  $iis_clusterIp = hiera('atomia::iis::cluster_ip','')
+  file { 'C:/Program Files (x86)/Atomia/AutomationServer/Common/Transformation Files/Resources.IIS.xml' :
+    ensure  => 'file',
+    content => template('atomia/resource_transformations/Resources.IIS.erb'),
+    require => File['C:/Program Files (x86)/Atomia/AutomationServer/Common/Transformation Files/'],
+  }
+
+  $mssql_serverIps = ''
+  $mssql_username  = ''
+  $mssql_password  = ''
+  file { 'C:/Program Files (x86)/Atomia/AutomationServer/Common/Transformation Files/Resources.MSSQL.xml' :
+    ensure  => 'file',
+    content => template('atomia/resource_transformations/Resources.MSSQL.erb'),
+    require => File['C:/Program Files (x86)/Atomia/AutomationServer/Common/Transformation Files/'],
+  }
+
+  $openstack_admin_user       = hiera('atomia::openstack::admin_user','')
+  $openstack_admin_password   = hiera('atomia::openstack::admin_password','')
+  $openstack_domain           = hiera('atomia::openstack::domain','')
+  $openstack_identity_uri     = hiera('atomia::openstack::identity_uri','')
+  $openstack_compute_uri      = hiera('atomia::openstack::compute_uri','')
+  $openstack_network_uri      = hiera('atomia::openstack::network_uri','')
+  $openstack_ceilometer_uri   = hiera('atomia::openstack::ceilometer_uri','')
+  $openstack_cinder_uri       = hiera('atomia::openstack::cinder_uri','')
+  $openstack_hypervisor       = hiera('atomia::openstack::hypervisor','')
+  $openstack_external_gateway = hiera('atomia::openstack::external_gateway','')
+  file { 'C:/Program Files (x86)/Atomia/AutomationServer/Common/Transformation Files/Resources.OpenStack.xml' :
+    ensure  => 'file',
+    content => template('atomia/resource_transformations/Resources.OpenStack.erb'),
+    require => File['C:/Program Files (x86)/Atomia/AutomationServer/Common/Transformation Files/'],
+  }
 }

--- a/manifests/rsyslog.pp
+++ b/manifests/rsyslog.pp
@@ -20,29 +20,29 @@
 #
 
 class atomia::rsyslog(
-    $is_server              = false,
-    $server_ip,
+  $is_server  = false,
+  $server_ip,
 ) {
 
-    if($is_server == true){
-        file{ '/etc/rsyslog.d/atomia-rsyslog-server.conf':
-            ensure      => present,
-            content     => "puppet:///modules/atomia/rsyslog/atomia-rsyslog-server.conf",
-        }
-
-        file{ '/etc/rsyslog.conf':
-            ensure      => present,
-            content     => "puppet:///modules/atomia/rsyslog/rsyslog-server.conf",
-        }
-    } else{
-        file{ '/etc/apache2/conf.d/log-to-syslog.conf':
-            ensure      => present,
-            content     => "ErrorLog syslog",
-        }
-
-        file{ '/etc/rsyslog.d/atomia-rsyslog-client.conf':
-            ensure      => present,
-            content     => template("atomia/rsyslog/atomia-rsyslog-client.conf.erb"),
-        }
+  if($is_server == true){
+    file{ '/etc/rsyslog.d/atomia-rsyslog-server.conf':
+      ensure  => present,
+      content => 'puppet:///modules/atomia/rsyslog/atomia-rsyslog-server.conf',
     }
+
+    file{ '/etc/rsyslog.conf':
+      ensure  => present,
+      content => 'puppet:///modules/atomia/rsyslog/rsyslog-server.conf',
+    }
+  } else{
+    file{ '/etc/apache2/conf.d/log-to-syslog.conf':
+      ensure  => present,
+      content => 'ErrorLog syslog',
+    }
+
+    file{ '/etc/rsyslog.d/atomia-rsyslog-client.conf':
+      ensure  => present,
+      content => template('atomia/rsyslog/atomia-rsyslog-client.conf.erb'),
+    }
+  }
 }

--- a/manifests/service_files.pp
+++ b/manifests/service_files.pp
@@ -2,7 +2,7 @@
 # == Class: atomia::service_files
 #
 # Deploys different service files such as parking, under construction websites
-# should be deployed on a node which has access to the shared storage. 
+# should be deployed on a node which has access to the shared storage.
 # Since these files are changed depending on environment the manifest expects
 # all files to be in the atomia file share.
 #
@@ -12,64 +12,64 @@
 # class {'atomia::service_files':}
 
 class atomia::service_files (
-  ) {
-  exec {"check_presence_public_html":
+) {
+  exec {'check_presence_public_html':
     command => '/bin/true',
-    onlyif => '/usr/bin/test -d /storage/content/systemservices/public_html',
+    onlyif  => '/usr/bin/test -d /storage/content/systemservices/public_html',
   }
 
-  exec {"check_presence_100000":
+  exec {'check_presence_100000':
     command => '/bin/true',
-    onlyif => '/usr/bin/test -d /storage/content/00/100000',
+    onlyif  => '/usr/bin/test -d /storage/content/00/100000',
   }
 
-  exec {"check_presence_00":
+  exec {'check_presence_00':
     command => '/bin/true',
-    onlyif => '/usr/bin/test -d /storage/content/00',
+    onlyif  => '/usr/bin/test -d /storage/content/00',
   }
-  
-  file { "/storage/content/00/100000":
-    ensure => directory,
-    owner  => root,
-    group  => root,
-    mode   => "710",
-    require => Exec["check_presence_00"],
+
+  file { '/storage/content/00/100000':
+    ensure  => directory,
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0710',
+    require => Exec['check_presence_00'],
   }
-  
+
   file { '/storage/content/systemservices/public_html/forward.php':
-  	source		=> "puppet:///atomia/service_files/forward.php",
-    mode    => "0755",
-    owner   => root,
-    group   => root,
+    source => 'puppet:///modules/atomia/service_files/forward.php',
+    mode   => '0755',
+    owner  => 'root',
+    group  => 'root',
   }
 
   file { '/storage/content/systemservices/public_html/index.php':
-    source    => "puppet:///atomia/service_files/index.php",
-    mode    => "0755",
-    owner   => root,
-    group   => root,
+    source => 'puppet:///modules/atomia/service_files/index.php',
+    mode   => '0755',
+    owner  => 'root',
+    group  => 'root',
   }
 
   file { '/storage/content/systemservices/public_html/suspend.php':
-    source    => "puppet:///atomia/service_files/suspend.php",
-    mode    => "0755",
-    owner   => root,
-    group   => root,
+    source => 'puppet:///modules/atomia/service_files/suspend.php',
+    mode   => '0755',
+    owner  => 'root',
+    group  => 'root',
   }
 
   file { '/storage/content/systemservices/public_html/nostats.html':
-    source    => "puppet:///atomia/service_files/nostats.html",
-    mode    => "0444",
-    owner   => root,
-    group   => root,
+    source => 'puppet:///modules/atomia/service_files/nostats.html',
+    mode   => '0444',
+    owner  => 'root',
+    group  => 'root',
   }
 
   # Under construction
   file { '/storage/content/00/100000/index.html.default':
-    source    => "puppet:///atomia/service_files/index.html.default",
-    mode    => "0644",
-    owner   => 100000,
-    group   => 100000,
+    source => 'puppet:///modules/atomia/service_files/index.html.default',
+    mode   => '0644',
+    owner  => 100000,
+    group  => 100000,
   }
 
 }

--- a/manifests/testenvironment/local_nfs_server.pp
+++ b/manifests/testenvironment/local_nfs_server.pp
@@ -1,10 +1,10 @@
 # Sets up a local nfs server for test purposes with the shares required for atomia
 class atomia::testenvironment::local_nfs_server(
-	$hostip='127.0.0.1',
-	$content_share_nfs_location=expand_default('[[content_share_nfs_location]]'),
-	$config_share_nfs_location=expand_default('[[config_share_nfs_location]]')
+  $hostip                     = '127.0.0.1',
+  $content_share_nfs_location = expand_default('[[content_share_nfs_location]]'),
+  $config_share_nfs_location  = expand_default('[[config_share_nfs_location]]')
 ) {
- 
+
   Package['nfs-kernel-server'] -> Service['nfs-kernel-server']
 
   package { 'nfs-kernel-server': ensure => present }
@@ -21,44 +21,44 @@ class atomia::testenvironment::local_nfs_server(
   file { '/export': ensure => directory, }
 
   file { '/export/configuration':
-      ensure  => directory,
-      require => File["/export"],
-      mode    => "711"
- }
-    
+    ensure  => directory,
+    require => File['/export'],
+    mode    => '0711'
+  }
+
   file { '/export/mail':
     ensure  => directory,
-    require => File["/export"],
-    mode    => "755"
-  }  
-  file { '/export/content':
-      ensure  => directory,
-      require => File["/export"],
-      mode    => "711"
+    require => File['/export'],
+    mode    => '0755'
   }
-  ->
-  file {'/etc/exports':
-    content => "/export/configuration 192.168.33.0/24(rw,async,no_root_squash,no_subtree_check)
-/export/content 192.168.33.0/24(rw,async,no_root_squash,no_subtree_check)
-/export/mail 192.168.33.0/24(rw,async,no_root_squash,no_subtree_check)
-",
+  file { '/export/content':
+    ensure  => directory,
+    require => File['/export'],
+    mode    => '0711'
+  }
+->
+file {'/etc/exports':
+  content => "/export/configuration 192.168.33.0/24(rw,async,no_root_squash,no_subtree_check)
+  /export/content 192.168.33.0/24(rw,async,no_root_squash,no_subtree_check)
+  /export/mail 192.168.33.0/24(rw,async,no_root_squash,no_subtree_check)
+  ",
   require => Package['nfs-kernel-server'],
-  notify => Service['nfs-kernel-server'],}
-  ->
-  mount { '/storage/content':
-    device => $content_share_nfs_location,
-    fstype => "nfs",
-    remounts => false,
-    options => "rw,noatime",
-    ensure => mounted,
-    require => [File['/storage/content'],File['/export/content'], File['/etc/exports']],
-  }  
-  mount { '/storage/configuration':
-    device => $config_share_nfs_location,
-    fstype => "nfs",
-    remounts => false,
-    options => "rw,noatime",
-    ensure => mounted,
-    require => [File['/storage/configuration'],File['/export/content'], File['/etc/exports']],
-  }  
+  notify  => Service['nfs-kernel-server'],}
+->
+mount { '/storage/content':
+  ensure   => mounted,
+  device   => $content_share_nfs_location,
+  fstype   => 'nfs',
+  remounts => false,
+  options  => 'rw,noatime',
+  require  => [File['/storage/content'],File['/export/content'], File['/etc/exports']],
+}
+mount { '/storage/configuration':
+  ensure   => mounted,
+  device   => $config_share_nfs_location,
+  fstype   => 'nfs',
+  remounts => false,
+  options  => 'rw,noatime',
+  require  => [File['/storage/configuration'],File['/export/content'], File['/etc/exports']],
+}
 }

--- a/manifests/windows_base.pp
+++ b/manifests/windows_base.pp
@@ -54,335 +54,335 @@
 
 
 class atomia::windows_base (
-  $appdomain        = "",
-  $actiontrail_host = "actiontrail",
-  $login_host       = "login",
-  $store_host	     	= "store",
-  $billing_host     = "billing",
-  $admin_host       = "admin",
-  $hcp_host         = "hcp",
-  $automationserver_host = "automationserver",
-  $mail_sender_address  = "",
-  $mail_server_host     = "",
-  $mail_server_port     = "25",
-  $mail_server_username = "",
-  $mail_server_password = "",
-  $mail_server_use_ssl  = "false",
-  $mail_reply_to    = "",
-  $storage_server_hostname = "",
-  $mail_dispatcher_interval = "30",
+  $appdomain                               = '',
+  $actiontrail_host                        = 'actiontrail',
+  $login_host                              = 'login',
+  $store_host                              = 'store',
+  $billing_host                            = 'billing',
+  $admin_host                              = 'admin',
+  $hcp_host                                = 'hcp',
+  $automationserver_host                   = 'automationserver',
+  $mail_sender_address                     = '',
+  $mail_server_host                        = '',
+  $mail_server_port                        = '25',
+  $mail_server_username                    = '',
+  $mail_server_password                    = '',
+  $mail_server_use_ssl                     = false,
+  $mail_reply_to                           = '',
+  $storage_server_hostname                 = '',
+  $mail_dispatcher_interval                = '30',
   $automationserver_encryption_cert_thumb,
   $billing_encryption_cert_thumb,
   $root_cert_thumb,
   $signing_cert_thumb,
-  $is_iis             = 0,
-  $enable_mssql         = "false",
-  $enable_postgresql    = "true",
-  ){
+  $is_iis                                  = 0,
+  $enable_mssql                            = false,
+  $enable_postgresql                       = true,
+){
 
-    File { source_permissions => ignore }
+  File { source_permissions => ignore }
 
-    $app_password = hiera('atomia::active_directory::app_password','')
-    $ad_domain  = hiera('atomia::active_directory::domain_name','')
-    $domainreg_service_url = hiera('atomia::domainreg::service_url','')
-    $domainreg_service_username = hiera('atomia::domainreg::service_username','')
-    $domainreg_service_password = hiera('atomia::domainreg::service_password','')
-    $database_server_host = hiera('atomia::atomia_database::server_address','')
-    $database_server_username = hiera('atomia::atomia_database::atomia_user','')
-    $database_server_password = hiera('atomia::atomia_database::atomia_password','')
-    $order_host = "order"
+  $app_password               = hiera('atomia::active_directory::app_password','')
+  $ad_domain                  = hiera('atomia::active_directory::domain_name','')
+  $domainreg_service_url      = hiera('atomia::domainreg::service_url','')
+  $domainreg_service_username = hiera('atomia::domainreg::service_username','')
+  $domainreg_service_password = hiera('atomia::domainreg::service_password','')
+  $database_server_host       = hiera('atomia::atomia_database::server_address','')
+  $database_server_username   = hiera('atomia::atomia_database::atomia_user','')
+  $database_server_password   = hiera('atomia::atomia_database::atomia_password','')
+  $order_host                 = 'order'
 
-    if( $is_iis == 0 ){
+  if( $is_iis == 0 ){
 
-      if($::vagrant) {
-        $actiontrail_ip = $ipaddress
-        $database_server = 'WINMASTER\SQLEXPRESS'
-        $mirror_database_server = ""
-      }
-      else
-      {
-        $factfile = 'C:/ProgramData/PuppetLabs/facter/facts.d/actiontrail_ip.txt'
-
-        # TODO: Get these from hiera
-        $database_server = ""
-        $mirror_database_server = ""
-		$actiontrail_ip = ""
-      }
-
-  	  dism { 'NetFx3':
-  	  	ensure 	=> present,
-  		all	=> true,
-  	  }
-
-  	  # 6.1 is 2008 R2, so this matches 2012 and forward
-  	  # see http://msdn.microsoft.com/en-us/library/windows/desktop/ms724832(v=vs.85).aspx
-  	  if versioncmp($kernelmajversion, "6.1") > 0 {
-  	    dism { 'NetFx4Extended-ASPNET45':
-  	      ensure => present,
-  	      all    => true,
-  	    }
-
-  	    dism { 'IIS-NetFxExtensibility45':
-  	      ensure => present,
-  	      all    => true,
-  	    }
-
-  	    dism { 'IIS-ASPNET45':
-  	      ensure => present,
-  	      all    => true,
-  	    }
-
-  	    dism { 'MSMQ-Services':
-  	      ensure => present,
-  	      all    => true,
-  	    }
-
-  	    dism { 'MSMQ':
-  	      ensure => present,
-  	      all    => true,
-  	    }
-
-  	    dism { 'windows-identity-foundation':
-  	      ensure => present,
-  	      all    => true,
-  	    }
-
-  	    dism { 'WCF-HTTP-Activation':
-  	      ensure => present,
-  	      all    => true,
-  	    }
-
-  	    dism { 'WCF-HTTP-Activation45':
-  	      ensure => present,
-  	      all    => true,
-  	    }
-
-  	    file { 'c:/install/app-pool-settings.ps1':
-  	        ensure => 'file',
-  	        source => "puppet:///modules/atomia/windows_base/app-pool-settings.ps1"
-  	    }
-
-  	    exec { 'app-pool-settings':
-  	        command => 'C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -executionpolicy remotesigned -file c:/install/app-pool-settings.ps1',
-  	        require => File["c:/install/app-pool-settings.ps1"]
-  	      }
-
-  	  }
-
-  	  dism { 'MSMQ-Server':
-  	      ensure => present,
-  	      all    => true,
-  	    }
-
-  	  # Install IIS and modules
-  	  dism { 'IIS-WebServerRole':
-  	      ensure => present,
-  	      all    => true,
-  	    }
-
-  	  dism { 'IIS-ISAPIFilter':
-  	      ensure => present,
-  	      all    => true,
-  	    }
-
-  	  dism { 'IIS-ISAPIExtensions':
-  	      ensure => present,
-  	      all    => true,
-  	    }
-
-  	  dism { 'IIS-NetFxExtensibility':
-  	      ensure => present,
-  	      all    => true,
-  	    }
-
-  	  dism { 'IIS-ASPNET':
-  	      ensure => present,
-  	      all    => true,
-  	    }
-
-  	  dism { 'IIS-CommonHttpFeatures':
-  	      ensure => present,
-  	      all    => true,
-  	    }
-
-  	  dism { 'IIS-StaticContent':
-  	      ensure => present,
-  	      all    => true,
-  	    }
-
-  	  dism { 'IIS-DefaultDocument':
-  	      ensure => present,
-  	      all    => true,
-  	    }
-
-  	  dism { 'IIS-ManagementConsole':
-  	      ensure => present,
-  	      all    => true,
-  	    }
-
-  	  dism { 'IIS-ManagementService':
-  	      ensure => present,
-  	      all    => true,
-  	    }
-
-  	  dism { 'IIS-HttpRedirect':
-  	      ensure => present,
-  	      all    => true,
-  	    }
+    if($::vagrant) {
+      $actiontrail_ip = $::ipaddress
+      $database_server = 'WINMASTER\SQLEXPRESS'
+      $mirror_database_server = ''
     }
-    # End IIS and modules
+    else
+    {
+      $factfile = 'C:/ProgramData/PuppetLabs/facter/facts.d/actiontrail_ip.txt'
 
-    if !defined(File["c:/install"]) {
-      file { 'c:/install': ensure => 'directory' }
+      # TODO: Get these from hiera
+      $database_server = ''
+      $mirror_database_server = ''
+      $actiontrail_ip = ''
     }
 
-    file { 'c:/install/base.ps1':
-      ensure => 'file',
-      source => "puppet:///modules/atomia/windows_base/baseinstall.ps"
+    dism { 'NetFx3':
+      ensure => present,
+      all    => true,
     }
 
-    file { 'c:/install/disableweakssl.reg':
-      ensure => 'file',
-      source => "puppet:///modules/atomia/windows_base/disableweakssl.reg"
-    }
-
-    file { 'c:/install/Windows6.1-KB2554746-x64.msu':
-      ensure => 'file',
-      source => "puppet:///modules/atomia/windows_base/Windows6.1-KB2554746-x64.msu"
-    }
-
-
-    # Install Packages with Chocolatey
-    exec { 'install-chocolatey':
-      command => "iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))",
-      provider  => powershell,
-      onlyif  => 'Test-Path C:\ProgramData\Chocolatey'
-    }
-
-    exec { 'set-chocolatey-path':
-      command => 'c:\windows\system32\cmd.exe /c SET PATH=%PATH%;%systemdrive%\ProgramData\chocolatey\bin',
-      creates => 'c:/install/chocolatey_installed.txt',
-      require  => Exec['install-chocolatey'],
-    }
-
-    package { 'GoogleChrome':
-      ensure  => installed,
-      provider  => 'chocolatey',
-      require  => Exec['set-chocolatey-path'],
-    }
-
-    package { 'notepadplusplus':
-      ensure  => installed,
-      provider  => 'chocolatey',
-      require  => Exec['set-chocolatey-path'],
-    }
-
-    package { 'vcredist2008':
-      ensure  => installed,
-      provider  => 'chocolatey',
-      require  => Exec['set-chocolatey-path'],
-    }
-
-    if versioncmp($kernelmajversion, "6.1") == 0 {
-      # Install .net40
-  	  file { 'c:/install/install_net40.ps1':
-  	    ensure => 'file',
-  	    source => "puppet:///modules/atomia/windows_base/install_net40.ps1",
-  	  }
-
-  	  exec { 'Install-NET40':
-  	    command => 'C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -executionpolicy remotesigned -file C:\install\install_net40.ps1',
-  	    creates => 'C:\install\installed_net40.txt',
-        require => File['c:/install/install_net40.ps1'],
-  	  }
-    }
-
-    # Install certificates
-    file { 'C:\install\install_certificates.ps1':
-      ensure => 'file',
-      source => "puppet:///modules/atomia/windows_base/install_certificates.ps1",
-      require => File['c:/install/certificates'],
-    }
-    exec { 'install-certificates':
-      command => 'C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -executionpolicy remotesigned -file C:\install\install_certificates.ps1',
-      creates => 'C:\install\install_certificates.txt',
-      require => File['C:\install\install_certificates.ps1'],
+    # 6.1 is 2008 R2, so this matches 2012 and forward
+    # see http://msdn.microsoft.com/en-us/library/windows/desktop/ms724832(v=vs.85).aspx
+    if versioncmp($::kernelmajversion, '6.1') > 0 {
+      dism { 'NetFx4Extended-ASPNET45':
+        ensure => present,
+        all    => true,
       }
 
-    # Install Atomia Installer
-    file { 'C:\install\install_atomia_installer.ps1':
+      dism { 'IIS-NetFxExtensibility45':
+        ensure => present,
+        all    => true,
+      }
+
+      dism { 'IIS-ASPNET45':
+        ensure => present,
+        all    => true,
+      }
+
+      dism { 'MSMQ-Services':
+        ensure => present,
+        all    => true,
+      }
+
+      dism { 'MSMQ':
+        ensure => present,
+        all    => true,
+      }
+
+      dism { 'windows-identity-foundation':
+        ensure => present,
+        all    => true,
+      }
+
+      dism { 'WCF-HTTP-Activation':
+        ensure => present,
+        all    => true,
+      }
+
+      dism { 'WCF-HTTP-Activation45':
+        ensure => present,
+        all    => true,
+      }
+
+      file { 'c:/install/app-pool-settings.ps1':
+        ensure => 'file',
+        source => 'puppet:///modules/atomia/windows_base/app-pool-settings.ps1'
+      }
+
+      exec { 'app-pool-settings':
+        command => 'C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -executionpolicy remotesigned -file c:/install/app-pool-settings.ps1',
+        require => File['c:/install/app-pool-settings.ps1']
+      }
+
+    }
+
+    dism { 'MSMQ-Server':
+      ensure => present,
+      all    => true,
+    }
+
+    # Install IIS and modules
+    dism { 'IIS-WebServerRole':
+      ensure => present,
+      all    => true,
+    }
+
+    dism { 'IIS-ISAPIFilter':
+      ensure => present,
+      all    => true,
+    }
+
+    dism { 'IIS-ISAPIExtensions':
+      ensure => present,
+      all    => true,
+    }
+
+    dism { 'IIS-NetFxExtensibility':
+      ensure => present,
+      all    => true,
+    }
+
+    dism { 'IIS-ASPNET':
+      ensure => present,
+      all    => true,
+    }
+
+    dism { 'IIS-CommonHttpFeatures':
+      ensure => present,
+      all    => true,
+    }
+
+    dism { 'IIS-StaticContent':
+      ensure => present,
+      all    => true,
+    }
+
+    dism { 'IIS-DefaultDocument':
+      ensure => present,
+      all    => true,
+    }
+
+    dism { 'IIS-ManagementConsole':
+      ensure => present,
+      all    => true,
+    }
+
+    dism { 'IIS-ManagementService':
+      ensure => present,
+      all    => true,
+    }
+
+    dism { 'IIS-HttpRedirect':
+      ensure => present,
+      all    => true,
+    }
+  }
+  # End IIS and modules
+
+  if !defined(File['c:/install']) {
+    file { 'c:/install': ensure => 'directory' }
+  }
+
+  file { 'c:/install/base.ps1':
+    ensure => 'file',
+    source => 'puppet:///modules/atomia/windows_base/baseinstall.ps'
+  }
+
+  file { 'c:/install/disableweakssl.reg':
+    ensure => 'file',
+    source => 'puppet:///modules/atomia/windows_base/disableweakssl.reg'
+  }
+
+  file { 'c:/install/Windows6.1-KB2554746-x64.msu':
+    ensure => 'file',
+    source => 'puppet:///modules/atomia/windows_base/Windows6.1-KB2554746-x64.msu'
+  }
+
+
+  # Install Packages with Chocolatey
+  exec { 'install-chocolatey':
+    command  => "iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))",
+    provider => powershell,
+    onlyif   => 'Test-Path C:\ProgramData\Chocolatey'
+  }
+
+  exec { 'set-chocolatey-path':
+    command => 'c:\windows\system32\cmd.exe /c SET PATH=%PATH%;%systemdrive%\ProgramData\chocolatey\bin',
+    creates => 'c:/install/chocolatey_installed.txt',
+    require => Exec['install-chocolatey'],
+  }
+
+  package { 'GoogleChrome':
+    ensure   => installed,
+    provider => 'chocolatey',
+    require  => Exec['set-chocolatey-path'],
+  }
+
+  package { 'notepadplusplus':
+    ensure   => installed,
+    provider => 'chocolatey',
+    require  => Exec['set-chocolatey-path'],
+  }
+
+  package { 'vcredist2008':
+    ensure   => installed,
+    provider => 'chocolatey',
+    require  => Exec['set-chocolatey-path'],
+  }
+
+  if versioncmp($::kernelmajversion, '6.1') == 0 {
+    # Install .net40
+    file { 'c:/install/install_net40.ps1':
       ensure => 'file',
-      source => "puppet:///modules/atomia/windows_base/install_atomia_installer.ps1",
+      source => 'puppet:///modules/atomia/windows_base/install_net40.ps1',
     }
 
-    exec { 'install-atomia-installer':
-      command => 'C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -executionpolicy remotesigned -file C:\install\install_atomia_installer.ps1',
-      creates => 'C:\install\install_atomia_installer.txt',
+    exec { 'Install-NET40':
+      command => 'C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -executionpolicy remotesigned -file C:\install\install_net40.ps1',
+      creates => 'C:\install\installed_net40.txt',
+      require => File['c:/install/install_net40.ps1'],
+    }
+  }
+
+  # Install certificates
+  file { 'C:\install\install_certificates.ps1':
+    ensure  => 'file',
+    source  => 'puppet:///modules/atomia/windows_base/install_certificates.ps1',
+    require => File['c:/install/certificates'],
+  }
+  exec { 'install-certificates':
+    command => 'C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -executionpolicy remotesigned -file C:\install\install_certificates.ps1',
+    creates => 'C:\install\install_certificates.txt',
+    require => File['C:\install\install_certificates.ps1'],
+  }
+
+  # Install Atomia Installer
+  file { 'C:\install\install_atomia_installer.ps1':
+    ensure => 'file',
+    source => 'puppet:///modules/atomia/windows_base/install_atomia_installer.ps1',
+  }
+
+  exec { 'install-atomia-installer':
+    command => 'C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -executionpolicy remotesigned -file C:\install\install_atomia_installer.ps1',
+    creates => 'C:\install\install_atomia_installer.txt',
+  }
+
+  file { 'C:\ProgramData\Atomia Installer\appupdater.ini':
+    ensure  => 'file',
+    source  => 'puppet:///modules/atomia/windows_base/appupdater.ini',
+    require => Exec['install-atomia-installer']
+  }
+
+  # Install other requirements
+  exec { 'base-install':
+    command => 'C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -executionpolicy remotesigned -file C:\install\base.ps1',
+    creates => 'C:\install\install_base.txt',
+  }
+
+
+  file { 'C:\Program Files (x86)\Atomia': ensure => 'directory' }
+
+  file { 'C:\Program Files (x86)\Atomia\Common': ensure => 'directory' }
+
+  file { 'unattended.ini':
+    ensure  => file,
+    path    => 'C:\Program Files (x86)\Atomia\Common\unattended.ini',
+    content => template('atomia/windows_base/ini_template.erb'),
+  }
+
+  file { 'C:\Program Files (x86)\Atomia\Common\atomia.ini.location': content => 'C:\Program Files (x86)\Atomia\Common', }
+
+  file { 'C:\install\recreate_all_config_files.ps1':
+    ensure => 'file',
+    source => 'puppet:///modules/atomia/windows_base/recreate_all_config_files.ps1'
+  }
+
+
+  if($::vagrant){
+    file { 'c:/install/certificates':
+      source  => 'puppet:///modules/atomiacerts/certificates',
+      recurse => true
     }
 
-    file { 'C:\ProgramData\Atomia Installer\appupdater.ini':
+    file { 'C:\inetpub\wwwroot\empty.crl':
       ensure => 'file',
-      source => "puppet:///modules/atomia/windows_base/appupdater.ini",
-      require => Exec['install-atomia-installer']
+      source => 'puppet:///modules/atomiacerts/empty.crl',
+    }
+  }
+  else {
+    file { 'c:/install/certificates':
+      source  => 'puppet:///modules/atomiacerts/certificates',
+      recurse => true
     }
 
-    # Install other requirements
-    exec { 'base-install':
-      command => 'C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -executionpolicy remotesigned -file C:\install\base.ps1',
-      creates => 'C:\install\install_base.txt',
-    }
-
-
-    file { 'C:\Program Files (x86)\Atomia': ensure => 'directory' }
-
-    file { 'C:\Program Files (x86)\Atomia\Common': ensure => 'directory' }
-
-    file { "unattended.ini":
-      path    => 'C:\Program Files (x86)\Atomia\Common\unattended.ini',
-      ensure  => file,
-      content => template('atomia/windows_base/ini_template.erb'),
-    }
-
-    file { 'C:\Program Files (x86)\Atomia\Common\atomia.ini.location': content => 'C:\Program Files (x86)\Atomia\Common', }
-
-    file { 'C:\install\recreate_all_config_files.ps1':
+    file { 'C:\inetpub\wwwroot\empty.crl':
       ensure => 'file',
-      source => "puppet:///modules/atomia/windows_base/recreate_all_config_files.ps1"
+      source => 'puppet:///modules/atomiacerts/empty.crl'
     }
 
-
-    if($::vagrant){
-		file { 'c:/install/certificates':
-			source  => 'puppet:///modules/atomiacerts/certificates',
-			recurse => true
-		}
-
-		file { 'C:\inetpub\wwwroot\empty.crl':
-			ensure => 'file',
-			source  => 'puppet:///modules/atomiacerts/empty.crl',
-		}
+    file { 'c:/install/install_atomia_application.ps1':
+      ensure  => 'file',
+      source  => 'puppet:///modules/atomia/windows_base/install_atomia_application.ps1',
+      require => File['c:/install']
     }
-    else {
-		file { 'c:/install/certificates':
-			source  => 'puppet:///atomiacerts/certificates',
-			recurse => true
-		}
 
-		file { 'C:\inetpub\wwwroot\empty.crl':
-			ensure => 'file',
-			source => "puppet:///atomiacerts/empty.crl"
-		}
-
-		file { 'c:/install/install_atomia_application.ps1':
-			ensure  => 'file',
-			source  => 'puppet:///modules/atomia/windows_base/install_atomia_application.ps1',
-			require => File['c:/install']
-		}
-
-		exec {'install-setuptools':
-			command	=> 'C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe -Executionpolicy Unrestricted -File c:/install/install_atomia_application.ps1 -repository PublicRepository -application "Atomia Setup Tools"',
-			require => [File['c:/install/install_atomia_application.ps1'], File['unattended.ini']],
-			creates => 'C:\Program Files (x86)\Atomia\Common\ADDT',
-		}
+    exec {'install-setuptools':
+      command => 'C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe -Executionpolicy Unrestricted -File c:/install/install_atomia_application.ps1 -repository PublicRepository -application "Atomia Setup Tools"',
+      require => [File['c:/install/install_atomia_application.ps1'], File['unattended.ini']],
+      creates => 'C:\Program Files (x86)\Atomia\Common\ADDT',
     }
+  }
 }


### PR DESCRIPTION
So using the script I wrote in #73 I cleaned up all the code. The script took about 3 minutes to run after which I manually fixed the remainder of the issues which took about 2 hours. Particularly the active directory scoping and powershell command escaping was hard to get right and I'm still not entirely sure if it's properly escaped. 

One though nut to crack was [adjoin_config.pp#L17](https://github.com/atomia/puppet-atomia/blob/master/manifests/adjoin_config.pp#L17) - what's `${content}` referring to here? It seems to be an empty variable so I removed it. Bug in the code or just something I'm not getting?

Have a look and let me know what you think! Also wondering if perhaps it's better to split it into 61 separate commits?

Travis seems to like it all now. :green_heart: