### PR TITLE
remove mail_plugin_dir from dovecot.conf since it's not being used

### DIFF
--- a/files/mailserver/dovecot.conf
+++ b/files/mailserver/dovecot.conf
@@ -36,7 +36,6 @@ protocol pop3 {
 }
 protocol lda {
   auth_socket_path = /var/run/dovecot/auth-master
-  mail_plugin_dir = /usr/lib/dovecot/modules
   mail_plugins = quota
   sendmail_path = /usr/lib/sendmail
 }


### PR DESCRIPTION
Having mail_plugin_dir in dovecot.conf without the dir actually existing prevents dovecot from starting on CentOS because the directory doesn't exist. 

```
doveconf: Fatal: Error in configuration file /etc/dovecot/dovecot.conf: mail_plugin_dir: access(/usr/lib/dovecot/modules) failed: No such file or directory
```

If puppet-atomia was using plugins for dovecot I would have made the dir configurable per OS-family but considering it doesn't seem to be doing that, I'm opting for its removal.