### PR TITLE
fix quoted boolean check for skip_mount

### DIFF
--- a/manifests/awstats.pp
+++ b/manifests/awstats.pp
@@ -46,7 +46,7 @@ class atomia::awstats (
     package { 'apache2-mpm-worker': ensure => installed }
   }
 
-  if $skip_mount == false {
+  if $skip_mount == 'false' {
 
 
     $internal_zone = hiera('atomia::internaldns::zone_name','')


### PR DESCRIPTION
adds back the quotes that were removed in the code cleanup