### PR TITLE
fix loading certs from atomiacerts resource

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,9 +2,9 @@ require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet-lint/tasks/puppet-lint'
 require 'puppet-syntax/tasks/puppet-syntax'
 
-#FIXME: disabling autoloader via disable_checks didn't work
+#FIXME: disabling the following checks via disable_checks didn't work
 PuppetLint.configuration.send("disable_autoloader_layout")
-
+PuppetLint.configuration.send("disable_puppet_url_without_modules")
 
 exclude_paths = [
   "pkg/**/*",

--- a/manifests/haproxy.pp
+++ b/manifests/haproxy.pp
@@ -266,7 +266,7 @@ class atomia::haproxy (
     if $certificate_default_cert == '' {
       file { '/etc/haproxy/atomia_certificates/default.pem':
         ensure  => file,
-        source  => 'puppet:///modules/atomiacerts/certificates/wildcard_with_key.pem',
+        source  => 'puppet:///atomiacerts/certificates/wildcard_with_key.pem',
         owner   => 'root',
         group   => 'root',
         mode    => '0755',

--- a/manifests/windows_base.pp
+++ b/manifests/windows_base.pp
@@ -353,24 +353,24 @@ class atomia::windows_base (
 
   if($::vagrant){
     file { 'c:/install/certificates':
-      source  => 'puppet:///modules/atomiacerts/certificates',
+      source  => 'puppet:///atomiacerts/certificates',
       recurse => true
     }
 
     file { 'C:\inetpub\wwwroot\empty.crl':
       ensure => 'file',
-      source => 'puppet:///modules/atomiacerts/empty.crl',
+      source => 'puppet:///atomiacerts/empty.crl',
     }
   }
   else {
     file { 'c:/install/certificates':
-      source  => 'puppet:///modules/atomiacerts/certificates',
+      source  => 'puppet:///atomiacerts/certificates',
       recurse => true
     }
 
     file { 'C:\inetpub\wwwroot\empty.crl':
       ensure => 'file',
-      source => 'puppet:///modules/atomiacerts/empty.crl'
+      source => 'puppet:///atomiacerts/empty.crl'
     }
 
     file { 'c:/install/install_atomia_application.ps1':


### PR DESCRIPTION
certs for haproxy and windows base are loaded from an incorrect resource. this patch fixes the paths and disables the check for linting on puppet resources without module dir. 

Alternative fix would be to move atomiacerts into puppet-atomia, but then the certs would have to be moved and puppetmaster's fileserver.conf would need to be patched with a fixer script or manually.