### PR TITLE
fix lve connection string provisioning

### DIFF
--- a/manifests/apache_agent_cl.pp
+++ b/manifests/apache_agent_cl.pp
@@ -55,8 +55,8 @@ class atomia::apache_agent_cl (
 
     $cloudlinux_database_password = hiera('atomia::daggre::cloudlinux_database_password','atomia123')
     exec { 'update lve-stats connections tring':
-      command => "/usr/bin/sed -i 's#connect_string=.*#connect_string=atomia-lve:${cloudlinux_database_password}@${daggre_ip}/lve#' /etc/sysconfig/lvestats2",
-      unless  => "/usr/bin/grep -c 'connect_string=atomia-lve:${cloudlinux_database_password}@${daggre_ip}/lve' /etc/sysconfig/lvestats2",
+      command => "/usr/bin/sed -i 's#connect_string =.*#connect_string = atomia-lve:${cloudlinux_database_password}@${daggre_ip}/lve#' /etc/sysconfig/lvestats2",
+      unless  => "/usr/bin/grep -c 'connect_string = atomia-lve:${cloudlinux_database_password}@${daggre_ip}/lve' /etc/sysconfig/lvestats2",
       notify  => Service['lvestats'],
       require => Exec['install lve-stats2'],
     }


### PR DESCRIPTION
This should fix #148 the connection string that needs changing contains spaces and we weren't specifying those.

The -c in the grep command isn't really need by the way, since the unless only monitors the exit code of the grep command and not the number returned by the count.

https://docs.puppet.com/puppet/latest/reference/types/exec.html#exec-attribute-unless