### PR TITLE
Set DISM module version to 1.2.0

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -13,7 +13,8 @@ mod "chocolatey",
   :git => "git://github.com/chocolatey/puppet-chocolatey.git"
 
 mod "dism",
-  :git => "git://github.com/puppetlabs/puppetlabs-dism.git"
+  :git => "git://github.com/puppetlabs/puppetlabs-dism.git",
+  :ref => "1.2.0"
 
 mod "openssl",
   :git => "git://github.com/camptocamp/puppet-openssl.git"


### PR DESCRIPTION
Windows server provisioning fails unless the DISM version is set to this tag 1.2.0.

Fixes #165