### PR TITLE
fix lvemanager and lve_packages provision

### DIFF
--- a/manifests/apache_agent_cl.pp
+++ b/manifests/apache_agent_cl.pp
@@ -85,7 +85,15 @@ class atomia::apache_agent_cl (
     }
 
     # Install alt-php
-    #package { 'lvemanager': ensure => installed }
+    package { 'lvemanager': ensure => installed }
+
+    file {'/storage/configuration/cloudlinux/lve_packages':
+      ensure  => 'present',
+      replace => 'no',
+      content => '#lve packages',
+      mode    => '0644',
+      require => [Package['lvemanager'],File['/storage']],
+    }
 
     exec { 'install altphp':
         command => '/usr/bin/yum -y groupinstall alt-php',


### PR DESCRIPTION
this should fix the puppet side of things. Ensuring the provisioning of lvemanager and lve_packages on the NFS mount