### PR TITLE
Add lookup script for lve packages

### DIFF
--- a/files/apache_agent/lve_packages.sh
+++ b/files/apache_agent/lve_packages.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+PDIR="/storage/configuration/cloudlinux"
+cd $PDIR
+
+case "$1" in
+        --list-all)
+
+                cat lve_packages
+
+        ;;
+        --userid=*)
+                uid=${1#*=}
+                cat lve_packages | grep $uid | awk '{ print $2 }'
+        ;;
+        --package=*)
+                pack=${1#*=}
+                cat lve_packages | grep $pack | awk '{ print $1 }'
+        ;;
+        --list-packages)
+                cat lve_packages | awk '{ print $2 }' | sort | uniq
+        ;;
+        *)
+                echo "Usage:
+--help               show this message
+--list-all           prints <userid package> pairs (accepts no parameters);
+--userid=id          prints package for a user specified
+--package=package    prints users for a package specified
+--list-packages      prints packages list"
+        ;;
+esac

--- a/manifests/apache_agent_cl.pp
+++ b/manifests/apache_agent_cl.pp
@@ -95,6 +95,18 @@ class atomia::apache_agent_cl (
       require => [Package['lvemanager'],File['/storage']],
     }
 
+    file {'/storage/configuration/cloudlinux/lve_packages.sh':
+      ensure  => 'present',
+      source  => 'puppet:///modules/atomia/apache_agent/lve_packages.sh',
+      mode    => '0755',
+      require => [Package['lvemanager'],File['/storage']],
+    }
+
+    exec {'enable lve package lookup':
+      command => '/usr/bin/echo "CUSTOM_GETPACKAGE_SCRIPT=/storage/configuration/cloudlinux/lve_packages.sh" >> /etc/sysconfig/cloudlinux',
+      unless  => '/bin/grep -c "/storage/configuration/cloudlinux/lve_packages.sh" /etc/sysconfig/cloudlinux'
+    }
+
     exec { 'install altphp':
         command => '/usr/bin/yum -y groupinstall alt-php',
         timeout => 1800,


### PR DESCRIPTION
Ties up the the loose ends with http://kb.cloudlinux.com/2015/02/integrating-lve-limits-with-packages-for-unsupported-control-panel/