### PR TITLE
windows_base.pp path is fixed and test_environment.yaml added

### DIFF
--- a/examples/hieradata/test_environment.yaml
+++ b/examples/hieradata/test_environment.yaml
@@ -1,7 +1,3 @@
 ---
 classes:
-   - atomia::active_directory
-   - atomia::windows_base
-   - atomia::atomia_database
-   - atomia::internal_apps
-   - atomia::public_apps
+   - atomia::test_environment

--- a/examples/hieradata/test_environment.yaml
+++ b/examples/hieradata/test_environment.yaml
@@ -1,0 +1,7 @@
+---
+classes:
+   - atomia::active_directory
+   - atomia::windows_base
+   - atomia::atomia_database
+   - atomia::internal_apps
+   - atomia::public_apps

--- a/manifests/windows_base.pp
+++ b/manifests/windows_base.pp
@@ -412,12 +412,12 @@ class atomia::windows_base (
   }
 
   file { 'c:/install/stop-atomia-services.ps1':
-    source  => 'puppet:///modules/windows_base/stop-atomia-services.ps1',
+    source  => 'puppet:///modules/atomia/windows_base/stop-atomia-services.ps1',
     require => File['c:/install']
   }
 
   file { 'c:/install/start-atomia-services.ps1':
-    source  => 'puppet:///modules/windows_base/start-atomia-services.ps1',
+    source  => 'puppet:///modules/atomia/windows_base/start-atomia-services.ps1',
     require => File['c:/install']
   }
 


### PR DESCRIPTION
test_environment.yaml is critical bug. This solution I have tested twice, it works flawlessly.

I could have put inside test_environment.yaml something like:
---
classes:
- atomia::test_environment

Since, we have new test_environment.pp manifest, but this is just cosmethic change which I never tested.