### PR TITLE
added net461 script

### DIFF
--- a/files/windows_base/install_net461.ps1
+++ b/files/windows_base/install_net461.ps1
@@ -1,0 +1,16 @@
+$location = "c:\install"
+Set-Location $location
+
+$client = new-object System.Net.WebClient
+
+if (!(Test-Path  (Join-Path $location "net461.exe")))
+{
+	"Downloading .net461"
+	$net4Url = "https://download.microsoft.com/download/E/4/1/E4173890-A24A-4936-9FC9-AF930FE3FA40/NDP461-KB3102436-x86-x64-AllOS-ENU.exe"
+	$client.DownloadFile( $net4Url, (Join-Path $location "net461.exe") )
+	$net4Log = Join-Path $location "net461.log"
+	"Installing .net4"
+	Start-Process net461.exe ("/q /log " + $net4Log) -wait
+}
+
+new-item C:\install\installed_net461.txt -itemtype file

--- a/manifests/internal_apps.pp
+++ b/manifests/internal_apps.pp
@@ -131,4 +131,21 @@ class atomia::internal_apps (
     require => Exec['install-automationserver'],
   }
 
+  # Install .NET framework 4.6.1
+  if versioncmp($::kernelmajversion, '6.1') > 0 {	# this matches 2012 and forward
+    if(!defined(File['c:/install/install_net461.ps1'])) {
+      file { 'c:/install/install_net461.ps1':
+        ensure => 'file',
+        source => 'puppet:///modules/atomia/windows_base/install_net461.ps1',
+      }
+   }
+
+    if(!defined(Exec['Install-NET461'])) {
+      exec { 'Install-NET461':
+        command => 'C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -executionpolicy remotesigned -file C:\install\install_net461.ps1',
+        creates => 'C:\install\installed_net461.txt',
+        require => File['c:/install/install_net461.ps1'],
+      }
+   }
+  }
 }

--- a/manifests/public_apps.pp
+++ b/manifests/public_apps.pp
@@ -102,4 +102,22 @@ exec {'install-bcp':
       content => 'atomia_role_1=atomia_public_apps',
     }
   }
+
+  # Install .NET framework 4.6.1
+  if versioncmp($::kernelmajversion, '6.1') > 0 {	# this matches 2012 and forward
+    if(!defined(File['c:/install/install_net461.ps1'])) {
+      file { 'c:/install/install_net461.ps1':
+        ensure => 'file',
+        source => 'puppet:///modules/atomia/windows_base/install_net461.ps1',
+      }
+   }
+
+    if(!defined(Exec['Install-NET461'])) {
+      exec { 'Install-NET461':
+        command => 'C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -executionpolicy remotesigned -file C:\install\install_net461.ps1',
+        creates => 'C:\install\installed_net461.txt',
+        require => File['c:/install/install_net461.ps1'],
+      }
+   }
+  }
   }


### PR DESCRIPTION
Added install_net461.ps1 script to comply with prerequisites.

Script is executed in internal_apps.pp and public_apps.pp instead of just windows_base.pp because the system will be rebooted at the end of the .net framework installation. Isn't better that reboot occures when everything is finished?