### PR TITLE
Update HaProxy to support enforcing SSL redirect

### DIFF
--- a/files/haproxy/sync_ssl_redirects.sh
+++ b/files/haproxy/sync_ssl_redirects.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+ssl_redirects_fiilepath='/etc/haproxy/ssl-redirects.lst'
+
+if [ -z "$1" ]; then
+  echo "usage: $0 rsync_path_to_ssl_redirect_folder"
+  echo "example:"
+  echo "$0 \"root@192.168.33.21:/storage/configuration\""
+  exit 1
+fi
+
+old_hash=$(md5sum "$ssl_redirects_fiilepath")
+
+rsync -z -e "ssh -o StrictHostKeyChecking=no" "$1"/ssl-redirects.lst /etc/haproxy 
+
+new_hash=$(md5sum "$ssl_redirects_fiilepath")
+
+if [ "$old_hash" != "$new_hash" ]; then
+  echo "OK: new ssl redirects loaded, reloading haproxy"
+  /etc/init.d/haproxy reload 
+fi

--- a/templates/haproxy/haproxy.conf.erb
+++ b/templates/haproxy/haproxy.conf.erb
@@ -36,6 +36,11 @@ frontend apachecluster
 	option  http-server-close
 	http-request add-header X-Proto https if { ssl_fc }
 
+	acl enforce_ssl hdr(host) -i -f /etc/haproxy/ssl-redirects.lst
+	acl is_http_req ssl_fc,not
+
+	http-request redirect scheme https if enforce_ssl is_http_req
+
 	acl acme_challenge path_beg /.well-known/acme-challenge/
         http-request use-service lua.stateless_acme_challenge if acme_challenge
 	default_backend apache_servers
@@ -45,6 +50,11 @@ frontend iiscluster
 	bind <%= @iis_cluster_ip %>:443 ssl crt /etc/haproxy/atomia_certificates/default.pem crt /etc/haproxy/atomia_certificates crt /var/lib/acme/haproxy
 	option  http-server-close
 	http-request add-header X-Proto https if { ssl_fc }
+
+	acl enforce_ssl hdr(host) -i -f /etc/haproxy/ssl-redirects.lst
+	acl is_http_req ssl_fc,not
+
+	http-request redirect scheme https if enforce_ssl is_http_req
 
 	acl acme_challenge path_beg /.well-known/acme-challenge/
         http-request use-service lua.stateless_acme_challenge if acme_challenge

--- a/templates/haproxy/sync_ssl_redirects.cron
+++ b/templates/haproxy/sync_ssl_redirects.cron
@@ -1,0 +1,1 @@
+* * * * * root flock -n /var/lock/ssl-redirects.lock /etc/haproxy/sync_ssl_redirects.sh "<%= @ssl_redirects_sync_source %>"


### PR DESCRIPTION
Change haproxy.conf to support enforcing SSL redirect per domain.
Add ssl-redirect.lst file which HaProxy will use to know for which
domains the SSL redirect needs to be enforced.
Add cron job to sync the ssl-redirect.lst file from shared storage.

Resolves PROD-319