### PR TITLE
Add SqlMaxPoolSize parameter

### DIFF
--- a/templates/windows_base/ini_template.erb
+++ b/templates/windows_base/ini_template.erb
@@ -9,6 +9,7 @@ Domain = <%= @ad_domain %>
 SqlServer = <%= @database_server %>
 FailoverSqlServer = <%= @mirror_database_server %>
 PublicHost = <%= @appdomain %>
+SqlMaxPoolSize = 500
 EnableMsSqlDeployment = <%= @enable_mssql %>
 EnablePostgreSqlDeployment = <%= @enable_postgresql %>
 <% if @enable_postgresql == 'true' || @enable_postgresql == true %>


### PR DESCRIPTION
Parameter SqlMaxPoolSize is added, and it's default
value set to 500 - which is more than enough for
most use cases. Should some customer need more,
unattended.ini file will be changed in customizations.

Partially resolves: PROD-410

ChangeLog:
 * [IMPROVEMENT] Added support for Sql Max Pool Size setting