### PR TITLE
Disabled nscd service from starting and ensured its stopped.

### DIFF
--- a/manifests/adjoin.pp
+++ b/manifests/adjoin.pp
@@ -146,5 +146,14 @@ class atomia::adjoin (
       mode   => '0644',
       source => 'puppet:///modules/atomia/adjoin/common-session',
     }
+
+    file { '/etc/nscd.conf':
+        ensure  => file,
+        owner   => 'root',
+        group   => 'root',
+        mode    => '0600',
+        content => template('atomia/adjoin/nscd.conf.erb'),
+        notify  => [ Service['unscd'], Service['nscd'] ],
+      }
   }
 }

--- a/manifests/fsagent.pp
+++ b/manifests/fsagent.pp
@@ -59,7 +59,7 @@ class atomia::fsagent (
   service { 'unscd':
     enable => true,
     ensure => 'running',
-    require  => [Package['unscd'],
+    require  => Package['unscd'],
   }
   
   if $::lsbdistrelease == '16.04' {

--- a/manifests/fsagent.pp
+++ b/manifests/fsagent.pp
@@ -51,6 +51,11 @@ class atomia::fsagent (
   }
   package { 'python-pkg-resources': ensure => present }
 
+  service { 'nscd':
+    enable => false,
+    ensure => 'stopped',
+  }
+  
   if $::lsbdistrelease == '16.04' {
     package { [
       'ruby2.3',

--- a/manifests/fsagent.pp
+++ b/manifests/fsagent.pp
@@ -58,7 +58,8 @@ class atomia::fsagent (
   }
   service { 'unscd':
     enable => true,
-    ensure => 'started'
+    ensure => 'running',
+    require  => [Package['unscd'],
   }
   
   if $::lsbdistrelease == '16.04' {

--- a/manifests/fsagent.pp
+++ b/manifests/fsagent.pp
@@ -46,6 +46,7 @@ class atomia::fsagent (
   package { 'g++': ensure => present }
   package { 'make': ensure => present }
   package { 'procmail': ensure => present }
+  package { 'unscd': ensure => present }
   if !defined(Package['atomia-manager']) {
     package { 'atomia-manager': ensure => present }
   }
@@ -54,6 +55,10 @@ class atomia::fsagent (
   service { 'nscd':
     enable => false,
     ensure => 'stopped',
+  }
+  service { 'unscd':
+    enable => true,
+    ensure => 'started'
   }
   
   if $::lsbdistrelease == '16.04' {

--- a/templates/adjoin/nscd.conf.erb
+++ b/templates/adjoin/nscd.conf.erb
@@ -1,6 +1,10 @@
 debug-level             0
 paranoia                no
+<% if @atomia_role_1  == 'fsagent' %>
+enable-cache            passwd          no
+<% else %>
 enable-cache            passwd          yes
+<% end %>
 positive-time-to-live   passwd          3600
 negative-time-to-live   passwd          20
 suggested-size          passwd          211
@@ -25,7 +29,11 @@ check-files             hosts           yes
 persistent              hosts           yes
 shared                  hosts           yes
 max-db-size             hosts           33554432
+<% if @atomia_role_1  == 'fsagent' %>
+enable-cache            services        no
+<% else %>
 enable-cache            services        yes
+<% end %>
 positive-time-to-live   services        28800
 negative-time-to-live   services        20
 suggested-size          services        211


### PR DESCRIPTION

Nscd is installed as a dependency not in any manifest files, so the safe solution is to disable it from starting and ensure the service is stopped instead of uninstalling the package, as it may be needed.

https://atomia.myjetbrains.com/youtrack/issue/PROD-382