### PR TITLE
PHP farm now uses /storage/configuration/php.ini

### DIFF
--- a/templates/apache_agent/php-fcgid-wrapper-custom.erb
+++ b/templates/apache_agent/php-fcgid-wrapper-custom.erb
@@ -9,7 +9,7 @@ fi
 PHP_FCGI_MAX_REQUESTS=10000
 export PHP_FCGI_MAX_REQUESTS
 
-php_cgi_exec="/opt/phpfarm/inst/bin/php-cgi-<%= @php_version %>"
+php_cgi_exec="/opt/phpfarm/inst/bin/php-cgi-<%= @php_version %> -c /storage/configuration/php.ini"
 
 homedir=`getent passwd "$uid" | cut -d : -f 6`
 if [ ! -z "$homedir" ] && [ -d "$homedir" ] && [ -f "$homedir/custom-php.ini" ]; then


### PR DESCRIPTION
When specific php versions were built then every version had it's separate php.ini file, which in the long run complicates the configuration of php. This fixes the problem by loading default configuration from /storage/configuration/php.ini for any php version that is managed by php farm.
