### PR TITLE
Fix lve_packages.sh script and cloudlinux config

### DIFF
--- a/files/apache_agent/lve_packages.sh
+++ b/files/apache_agent/lve_packages.sh
@@ -20,6 +20,9 @@ case "$1" in
         --list-packages)
                 cat lve_packages | awk '{ print $2 }' | sort | uniq
         ;;
+        --list-resellers-packages)
+                echo " "
+        ;;
         *)
                 echo "Usage:
 --help               show this message

--- a/manifests/apache_agent_cl.pp
+++ b/manifests/apache_agent_cl.pp
@@ -103,7 +103,7 @@ class atomia::apache_agent_cl (
     }
 
     exec {'enable lve package lookup':
-      command => '/usr/bin/echo "CUSTOM_GETPACKAGE_SCRIPT=/storage/configuration/cloudlinux/lve_packages.sh" >> /etc/sysconfig/cloudlinux',
+      command => '/usr/bin/echo -e "\nCUSTOM_GETPACKAGE_SCRIPT=/storage/configuration/cloudlinux/lve_packages.sh" >> /etc/sysconfig/cloudlinux',
       unless  => '/bin/grep -c "/storage/configuration/cloudlinux/lve_packages.sh" /etc/sysconfig/cloudlinux'
     }
 


### PR DESCRIPTION
Modified lve_packages.sh script to include an additional option for
reseller that is needed in the new CloudLinux version or you can't
properly list the packages.
Also in puppet code the CUSTOM_GETPACKAGE_SCRIPT line was appended at
the end of the file but no newline was added in front of the line.

Resolves compatiblity issues with some tools.

Changelog
-