### PR TITLE
Fix config file and lve_packages.sh

### DIFF
--- a/files/apache_agent/lve_packages.sh
+++ b/files/apache_agent/lve_packages.sh
@@ -20,6 +20,9 @@ case "$1" in
         --list-packages)
                 cat lve_packages | awk '{ print $2 }' | sort | uniq
         ;;
+        --list-resellers-packages)
+                echo " "
+        ;;
         *)
                 echo "Usage:
 --help               show this message

--- a/manifests/apache_agent_cl.pp
+++ b/manifests/apache_agent_cl.pp
@@ -120,7 +120,7 @@ class atomia::apache_agent_cl (
   }
 
   exec {'enable lve package lookup':
-    command => '/usr/bin/echo "CUSTOM_GETPACKAGE_SCRIPT=/storage/configuration/cloudlinux/lve_packages.sh" >> /etc/sysconfig/cloudlinux',
+    command => '/usr/bin/echo -e "\nCUSTOM_GETPACKAGE_SCRIPT=/storage/configuration/cloudlinux/lve_packages.sh" >> /etc/sysconfig/cloudlinux',
     unless  => '/bin/grep -c "/storage/configuration/cloudlinux/lve_packages.sh" /etc/sysconfig/cloudlinux'
   }
 


### PR DESCRIPTION
Fixed adding of newline in front of new option CUSTOM_GETPACKAGE_SCRIPT line. As that way custom packages map file was not loaded correctly.
Other fix is an added option to the lve_packages.sh that is --list-resellers-packages.