### PR TITLE
Added protect base and enabling of epel repo

### DIFF
--- a/templates/apache_agent/rhnplugin.conf.erb
+++ b/templates/apache_agent/rhnplugin.conf.erb
@@ -1,0 +1,20 @@
+[main]
+enabled = 1
+gpgcheck = 1
+timeout = 120
+<% if @operatingsystemmajrelease == "7" %>
+
+[cloudlinux-x86_64-server-7]
+protect = 1
+<% elsif  @operatingsystemmajrelease == "6" %>
+
+[cloudlinux-x86_64-server-6]
+protect = 1
+<% else %>
+
+[cloudlinux-x86_64-server-5]
+protect = 1
+<% end %>
+
+[cloudlinux-base]
+protect = 1


### PR DESCRIPTION
In order for CloudLinux environment to be setup correctly we need to first install the protect base package and set it up according to the version. Also we need to setup the epel repo and enable it.

This fixes those two issues.