### PR TITLE
Fix librarian not found

### DIFF
--- a/setup-puppet-rhel
+++ b/setup-puppet-rhel
@@ -77,7 +77,8 @@ echo "mod \"atomia\", :git =>\"git://github.com/atomia/puppet-atomia.git\", :ref
 cd /etc/puppet
 
 sudo gem install --no-rdoc --no-ri librarian-puppet -v 2.2.3
-HOME=/root librarian-puppet install
+HOME=/root 
+sudo /usr/local/bin/librarian-puppet install
 sudo cp /etc/puppet/modules/atomia/files/default_files/* /etc/puppet/atomia/service_files/
 
 mkdir -p /etc/puppet/manifests/


### PR DESCRIPTION
There was an error that librarian was not added to the path. This does
not happen when command is ran via regular tty, only when script is
executed via nodejs since paths are not imported. To fix this absolute
path was used for librarian-puppet.

Amends PROD-1931.

Changelog:
* [FIX] - Fix CentOS install script for librarian.