### PR TITLE
Add missing 'AND' clause

### DIFF
--- a/templates/mailserver/dovecot-sql.conf.erb
+++ b/templates/mailserver/dovecot-sql.conf.erb
@@ -2,4 +2,4 @@ driver = mysql
 connect = host=<%= @db_hosts %> dbname=<%= @db_name %> user=<%= @db_user %> password=<%= @db_pass %>
 default_pass_scheme = CRYPT
 user_query = SELECT CONCAT('maildir:<%= @mailbox_base %>/', maildir) AS mail, '2000' AS uid, '2000' AS gid, CONCAT('maildir:storage=', floor(quota*1024)) AS quota FROM user WHERE email = (SELECT IF((SELECT email from user where email = '%u') is not null, '%u', CONCAT('@','%d')))
-password_query = SELECT email AS user, NULL as password, 'Y' as nopassword FROM user WHERE email = '%u' AND (ENCRYPT('%w', LEFT(password, 2)) = password OR MD5('%w') = password)
+password_query = SELECT email AS user, NULL as password, 'Y' as nopassword FROM user WHERE email = '%u' AND (ENCRYPT('%w', LEFT(password, 2)) = password OR MD5('%w') = password) AND status = 'active'

--- a/templates/mailserver/mysql_virtual_mailbox_maps.cf.erb
+++ b/templates/mailserver/mysql_virtual_mailbox_maps.cf.erb
@@ -2,4 +2,4 @@ hosts = <%= @db_hosts %>
 dbname = <%= @db_name %>
 user = <%= @db_user %>
 password = <%= @db_pass %>
-query = SELECT maildir FROM user WHERE email = '%s'
+query = SELECT maildir FROM user WHERE email = '%s' AND status = 'active'


### PR DESCRIPTION
Added missing 'AND' clause for checking that the account is
still active. Without this check, email account will be able to
login to the web mail, send and receive messages.

Resolves PROD-2116.

ChangeLog:
* [FIX] Added missing 'AND' clause in a user query.