### PR TITLE
Fix vagrant master DNS settings, Atomia installer

### DIFF
--- a/files/windows_base/install_atomia_installer.ps1
+++ b/files/windows_base/install_atomia_installer.ps1
@@ -3,13 +3,13 @@ Set-Location $location
 
 $client = new-object System.Net.WebClient
 "Downloading Atomia Installer"
-$InstallerUrl = "http://installer.atomia.com/Atomia%20Installer-1.4.3.exe"
+$InstallerUrl = "http://installer.atomia.com/AtomiaInstaller-latest.exe"
 $client.DownloadFile( $InstallerUrl, (Join-Path $location "AtomiaInstaller.exe") )
 $Ar = New-Object  system.security.accesscontrol.filesystemaccessrule("VAGRANT\Administrator","FullControl","Allow")
 $Acl = Get-Acl((Join-Path $location "AtomiaInstaller.exe"))
 $Acl.SetAccessRule($Ar)
 Set-Acl (Join-Path $location "AtomiaInstaller.exe") $Acl
-Start-Process c:\install\AtomiaInstaller.exe ("/q /log AtomiaInstaller.txt /S") 
+Start-Process c:\install\AtomiaInstaller.exe ("/q /log AtomiaInstaller.txt /S")
 Start-Sleep -s 10
 $WshShell = New-Object -comObject WScript.Shell
 $Shortcut = $WshShell.CreateShortcut("$Home\Desktop\AtomiaInstaller.lnk")


### PR DESCRIPTION
After executing vagrant up master the machine did not provision without
first modifying the Ethernet interface to have 127.0.0.1 and 8.8.8.8 as
DNS servers. Now, these two DNS entries are added and chocolatey is able
to download the needed applications and Atomia installer.

The other issues are that Atomia installer was not installed
because it was not available anymore from the old installer.atomia.com
URL. Now we fetch Atomia installer from:
 installer.atomia.com/AtomiaInstaller-latest.exe
This allows us to always update the installer when needed.

In order for this to be applied developers would need to either clone
new vagrant-atomia repo or update the submodules.

Resolves PROD-2143.

ChangeLog:
* [FIX] - DNS settings on Vagrant now setup correctly.
* [FIX] - Newest Atomia installer is now downloaded and installed.