### PR TITLE
Fix AD join errors and glusterfs

### DIFF
--- a/manifests/adjoin.pp
+++ b/manifests/adjoin.pp
@@ -146,14 +146,5 @@ class atomia::adjoin (
       mode   => '0644',
       source => 'puppet:///modules/atomia/adjoin/common-session',
     }
-
-    file { '/etc/nscd.conf':
-        ensure  => file,
-        owner   => 'root',
-        group   => 'root',
-        mode    => '0600',
-        content => template('atomia/adjoin/nscd.conf.erb'),
-        notify  => [ Service['unscd'], Service['nscd'] ],
-      }
   }
 }

--- a/manifests/fsagent.pp
+++ b/manifests/fsagent.pp
@@ -49,22 +49,26 @@ class atomia::fsagent (
   package { 'g++': ensure => present }
   package { 'make': ensure => present }
   package { 'procmail': ensure => present }
-  package { 'unscd': ensure => present }
+  package { 'nscd': ensure => present }
   if !defined(Package['atomia-manager']) {
     package { 'atomia-manager': ensure => present }
   }
   package { 'python-pkg-resources': ensure => present }
 
   service { 'nscd':
-    enable => false,
-    ensure => 'stopped',
-  }
-  service { 'unscd':
     enable => true,
     ensure => 'running',
-    require  => Package['unscd'],
+    require  => Package['nscd'],
   }
-  
+  file { '/etc/nscd.conf':
+        ensure  => file,
+        owner   => 'root',
+        group   => 'root',
+        mode    => '0600',
+        content => template('atomia/adjoin/nscd.conf.erb'),
+        notify  => Service['nscd'],
+        require => Package['nscd'],
+  }
   if $::lsbdistrelease == '16.04' {
     package { [
       'ruby2.3',

--- a/manifests/glusterfs.pp
+++ b/manifests/glusterfs.pp
@@ -202,6 +202,7 @@ class atomia::glusterfs (
     device  => "${gluster_hostname}:/web_volume",
     options => 'defaults,_netdev',
     fstype  => 'glusterfs',
+    remounts => false,
     require => [Exec['start web volume'], File['/storage']],
   }
 
@@ -257,6 +258,7 @@ class atomia::glusterfs (
     device  => "${gluster_hostname}:/config_volume",
     options => 'defaults,_netdev',
     fstype  => 'glusterfs',
+    remounts => false,
     require => [Exec['start config volume'], File['/storage']],
   }
 

--- a/templates/active_directory/add_users_vagrant.ps1.erb
+++ b/templates/active_directory/add_users_vagrant.ps1.erb
@@ -2,22 +2,23 @@
 
 Function AddUserToActiveDirectory($adUser,$password){
     Try{
-        
+
         New-ADUser $adUser
         Set-ADAccountPassword -Identity $adUser -Reset -NewPassword (ConvertTo-SecureString -AsPlainText $password -Force)
         Enable-ADAccount -Identity $adUser
+        Set-ADUser -Identity $adUser -PasswordNeverExpires $true
         return 1
     }
     Catch{
         $error[0]
         "Could not create user"
         return 0
-    }    
+    }
 
 }
 
 Function UserExists($aduser){
-    
+
     $user = Get-ADUser $aduser -Properties Name,DistinguishedName
 
     if($user.Name -eq $nul){
@@ -79,15 +80,15 @@ foreach($s in $c) {
 
 if( $currentSetting -notlike "*$($sidstr)*" ) {
 	Write-Host "Modify Setting ""Logon as a Service""" -ForegroundColor DarkCyan
-	
+
 	if( [string]::IsNullOrEmpty($currentSetting) ) {
 		$currentSetting = "*$($sidstr)"
 	} else {
 		$currentSetting = "*$($sidstr),$($currentSetting)"
 	}
-	
+
 	Write-Host "$currentSetting"
-	
+
 	$outfile = @"
 [Unicode]
 Unicode=yes
@@ -99,18 +100,18 @@ SeServiceLogonRight = $($currentSetting)
 "@
 
 	$tmp2 = [System.IO.Path]::GetTempFileName()
-	
-	
+
+
 	Write-Host "Import new settings to Local Security Policy" -ForegroundColor DarkCyan
 	$outfile | Set-Content -Path $tmp2 -Encoding Unicode -Force
 
 	#notepad.exe $tmp2
 	Push-Location (Split-Path $tmp2)
-	
+
 	try {
 		secedit.exe /configure /db "secedit.sdb" /cfg "$($tmp2)" /areas USER_RIGHTS 
 		#write-host "secedit.exe /configure /db ""secedit.sdb"" /cfg ""$($tmp2)"" /areas USER_RIGHTS "
-	} finally {	
+	} finally {
 		Pop-Location
 	}
 } else {


### PR DESCRIPTION
There was an issue with joining fsagent, glusterfs and apache to a
active directory domain. The issue was with using unscd instead of
relying on nscd. Caching for nscd has been disabled only on fsagent.

Issues with remounting storage were also resolved by using newer version
of puppet module for fstab. Changes are needed to the vagrant-atomia to
be applied on vagrant, because of using older module for fstab. This is
why this then partially resolves this issue for vagrant.

Partially resolves PROD-2144