### PR TITLE
Set TestRepository as default for vagrant

### DIFF
--- a/files/windows_base/appupdater-vagrant.ini
+++ b/files/windows_base/appupdater-vagrant.ini
@@ -1,0 +1,36 @@
+[Window]
+y = 0
+width = 1194
+x = 0
+height = 798
+
+[global]
+search_dirs = C:\Windows\System32\WindowsPowerShell\v1.0\, C:\Windows\System32\Wbem, ${APPDATA}\Microsoft\Windows\Start Menu, ${SYSTEMDRIVE}\python25, C:\Windows, ${WINDIR}\system32, C:\ProgramData\Microsoft\Windows\Start Menu, ${PROGRAMFILES(X86)}, C:\Users\Administrator.KIGUNA\AppData\Roaming\Microsoft\Windows\Start Menu, ${SYSTEMDRIVE}\perl, C:\Windows\system32, ${ALLUSERSPROFILE}\Microsoft\Windows\Start Menu, ${PROGRAMFILES}
+metalink = ${PROGRAMFILES}\Aria2\aria2c.exe
+http_proxy = 
+sig_check = SKIP
+https_proxy = 
+unknown_txt = C:\ProgramData\Atomia Installer\unknown.txt
+temp_dir = C:\ProgramData\Atomia Installer\temp
+apps_xml = http://installer.atomia.com/TestRepository/Apps.xml
+ignore_regex = ${WINDIR}\ServicePackFiles, ${WINDIR}\\$NtUninstall
+status = security, stable, beta
+unzip = C:\Program Files (x86)\Atomia Installer\unzip.exe
+auto_download = False
+reporting = True
+ftp_proxy = 
+cache_dir = C:\ProgramData\Atomia Installer
+auto_install = False
+refresh_expire = 604800
+metalink_params = -M %i -d %cache --allow-overwrite=true
+update_expire = 86400
+unzip_params = %i -d "%tempdir"
+keyring = C:\Program Files (x86)\Atomia Installer\Atomia.gpg
+ignore = 
+auto_key = False
+gnupg = 
+package_lists = 
+cmd_prefix = powershell -ExecutionPolicy Unrestricted -sta -file "C:\Program Files (x86)\Atomia Installer\runcommands.ps1" "%cache"
+installed_txt = C:\ProgramData\Atomia Installer\installed.txt
+index_hour = 2
+

--- a/manifests/windows_base.pp
+++ b/manifests/windows_base.pp
@@ -437,10 +437,19 @@ class atomia::windows_base (
     ensure  => directory,
   }
 
-  file { 'C:\ProgramData\Atomia Installer\appupdater.ini':
-    ensure  => 'file',
-    source  => 'puppet:///modules/atomia/windows_base/appupdater.ini',
-    require => [Exec['install-atomia-installer'], File['C:\ProgramData\Atomia Installer']],
+  if($::vagrant){
+    # For Vagrant use TestRepository appupdater ini file
+    file { 'C:\ProgramData\Atomia Installer\appupdater.ini':
+      ensure  => 'file',
+      source  => 'puppet:///modules/atomia/windows_base/appupdater-vagrant.ini',
+      require => [Exec['install-atomia-installer'], File['C:\ProgramData\Atomia Installer']],
+    }
+  } else {
+    file { 'C:\ProgramData\Atomia Installer\appupdater.ini':
+      ensure  => 'file',
+      source  => 'puppet:///modules/atomia/windows_base/appupdater.ini',
+      require => [Exec['install-atomia-installer'], File['C:\ProgramData\Atomia Installer']],
+    }
   }
 
   # Install other requirements


### PR DESCRIPTION
By default when Atomia applications are installed via AtomiaCMD
installer they are installed from the TestRepo. After when Atomia
installer is installed on the system default repo is set to
PublicRepository which is not needed for development. In order for the
environment to be ready for developers and QA TestRepository is set by
default for the Atomia installer when provisioned via vagrant.

Resolves PROD-2164.