### PR TITLE
Remove nscd to fix fsagent provisioning

### DIFF
--- a/manifests/fsagent.pp
+++ b/manifests/fsagent.pp
@@ -49,26 +49,12 @@ class atomia::fsagent (
   package { 'g++': ensure => present }
   package { 'make': ensure => present }
   package { 'procmail': ensure => present }
-  package { 'nscd': ensure => present }
+  package { 'nscd': ensure => absent }
   if !defined(Package['atomia-manager']) {
     package { 'atomia-manager': ensure => present }
   }
   package { 'python-pkg-resources': ensure => present }
 
-  service { 'nscd':
-    enable => true,
-    ensure => 'running',
-    require  => Package['nscd'],
-  }
-  file { '/etc/nscd.conf':
-        ensure  => file,
-        owner   => 'root',
-        group   => 'root',
-        mode    => '0600',
-        content => template('atomia/adjoin/nscd.conf.erb'),
-        notify  => Service['nscd'],
-        require => Package['nscd'],
-  }
   if $::lsbdistrelease == '16.04' {
     package { [
       'ruby2.3',


### PR DESCRIPTION
Removed nscd package in order to allow AD accounts to be visible without
caching on fsagent.

Amends PROD-2144.