### PR TITLE
Improve haproxy to handle https request by default

### DIFF
--- a/templates/haproxy/haproxy.conf.erb
+++ b/templates/haproxy/haproxy.conf.erb
@@ -35,8 +35,9 @@ frontend apachecluster
 
 	acl enforce_ssl hdr(host) -i -f /etc/haproxy/ssl-redirects.lst
 	acl is_http_req ssl_fc,not
+	acl is_acme path_beg /.well-known/acme-challenge/
 
-	http-request redirect scheme https if enforce_ssl is_http_req
+	http-request redirect scheme https if enforce_ssl is_http_req !is_acme
 
 	acl acme_challenge path_beg /.well-known/acme-challenge/
 		http-request use-service lua.stateless_acme_challenge if acme_challenge
@@ -50,8 +51,9 @@ frontend iiscluster
 
 	acl enforce_ssl hdr(host) -i -f /etc/haproxy/ssl-redirects.lst
 	acl is_http_req ssl_fc,not
+	acl is_acme path_beg /.well-known/acme-challenge/
 
-	http-request redirect scheme https if enforce_ssl is_http_req
+	http-request redirect scheme https if enforce_ssl is_http_req !is_acme
 
 	acl acme_challenge path_beg /.well-known/acme-challenge/
 		http-request use-service lua.stateless_acme_challenge if acme_challenge


### PR DESCRIPTION
Changed haproxy configuration to handle https request and acme
challenge.

Resolves PROD-2358.

ChangeLog:
* [IMRPOVEMENT] Improve haproxy to handle https request by default.